### PR TITLE
fix(client): disable hotbar keybind when invHotkeys are disabled

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -852,7 +852,7 @@ local function registerCommands()
 		description = locale('disable_hotbar'),
 		defaultKey = client.keys[3],
 		onPressed = function()
-			if EnableWeaponWheel or IsNuiFocused() or lib.progressActive() then return end
+			if EnableWeaponWheel or not invHotkeys or IsNuiFocused() or lib.progressActive() then return end
 			SendNUIMessage({ action = 'toggleHotbar' })
 		end
 	})


### PR DESCRIPTION
If you disable inventory hotkeys by `LocalPlayer.state.invHotkeys = false`, hotbar should be disabled too.