### PR TITLE
feat(client): add convar to disable steal command

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -737,7 +737,9 @@ local invHotkeys = false
 
 ---@type function?
 local function registerCommands()
-	RegisterCommand('steal', openNearbyInventory, false)
+	if client.enablestealcommand then
+		RegisterCommand('steal', openNearbyInventory, false)
+	end
 
 	local function openGlovebox(vehicle)
 		if not IsPedInAnyVehicle(playerPed, false) or not NetworkGetEntityIsNetworked(vehicle) then return end

--- a/init.lua
+++ b/init.lua
@@ -93,6 +93,7 @@ else
         ignoreweapons = json.decode(GetConvar('inventory:ignoreweapons', '[]')),
         suppresspickups = GetConvarInt('inventory:suppresspickups', 1) == 1,
         disableweapons = GetConvarInt('inventory:disableweapons', 0) == 1,
+        enablestealcommand = GetConvarInt('inventory:enablestealcommand', 1) == 1,
     }
 
     local ignoreweapons = table.create(0, (client.ignoreweapons and #client.ignoreweapons or 0) + 3)


### PR DESCRIPTION
Added convar `inventory:enablestealcommand` to enable or disable registering the `/steal` command.
The convar defaults to the original behavior (enable `/steal` command)

```cfg
setr inventory:enablestealcommand 1 # true (default)
setr inventory:enablestealcommand 0 # false
```

I will create docs PR once this gets approved.