### PR TITLE
feat(client): add convar to disable inventory setup notification

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1334,7 +1334,10 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inven
 
 	PlayerData.loaded = true
 
-	lib.notify({ description = locale('inventory_setup') })
+	if not client.disablesetupnotification then
+		lib.notify({ description = locale('inventory_setup') })
+	end
+
 	Shops.refreshShops()
 	Inventory.Stashes()
 	Inventory.Evidence()

--- a/init.lua
+++ b/init.lua
@@ -93,6 +93,7 @@ else
         ignoreweapons = json.decode(GetConvar('inventory:ignoreweapons', '[]')),
         suppresspickups = GetConvarInt('inventory:suppresspickups', 1) == 1,
         disableweapons = GetConvarInt('inventory:disableweapons', 0) == 1,
+        disablesetupnotification = GetConvarInt('inventory:disablesetupnotification', 0) == 1,
     }
 
     local ignoreweapons = table.create(0, (client.ignoreweapons and #client.ignoreweapons or 0) + 3)


### PR DESCRIPTION
Added convar `inventory:disablesetupnotification` to disable the "inventory setup" notification.
The convar defaults to the original behavior (enable setup notification)

![image](https://github.com/user-attachments/assets/362e22b1-e371-4578-b0f4-f128b5190871)

```cfg
setr inventory:disablesetupnotification 0 # false (default)
setr inventory:disablesetupnotification 1 # true
```

I will create docs PR once this gets approved.