### PR TITLE
feat(client/utils): add function to suppress item notifications

### DIFF
--- a/modules/utils/client.lua
+++ b/modules/utils/client.lua
@@ -79,8 +79,18 @@ end
 RegisterNetEvent('ox_inventory:notify', Utils.Notify)
 exports('notify', Utils.Notify)
 
+local notifySuppressed = false
+
+---@param value boolean
+local function setNotifySuppressed(value)
+    notifySuppressed = value
+end
+
+RegisterNetEvent('ox_inventory:suppressItemNotifications', setNotifySuppressed)
+exports('suppressItemNotifications', setNotifySuppressed)
+
 function Utils.ItemNotify(data)
-    if not client.itemnotify then
+    if notifySuppressed or not client.itemnotify then
         return
     end
 


### PR DESCRIPTION
Added net event (`ox_inventory:suppressItemNotifications`) and export (`suppressItemNotifications`) to temporarily suppress item notifications.

```lua
local playerId = 1
TriggerClientEvent('ox_inventory:suppressItemNotifications', playerId , true)
exports.ox_inventory:AddItem(playerId, 'water', 1)
TriggerClientEvent('ox_inventory:suppressItemNotifications', playerId , false)
```

I will create docs PR once this gets approved.