### PR TITLE
chore: update cfxlua extension id

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["communityox.cfxlua-vscode", "sumneko.lua"]
+  "recommendations": ["communityox.cfxlua-vscode-cox", "sumneko.lua"]
 }


### PR DESCRIPTION
This PR fixes wrong extension ID of the CfxLua IntelliSense extension.