### PR TITLE
fix(server): nil check before accessing inventory instance

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -2413,9 +2413,11 @@ local function giveItem(playerId, slot, target, count)
 	local fromInventory = Inventory(playerId)
 	local toInventory = Inventory(target)
 
+	if not fromInventory or not toInventory then return end
+
 	if count <= 0 then count = 1 end
 
-	if toInventory?.player then
+	if toInventory.player then
 		local data = fromInventory.items[slot]
 
 		if not data then return end

--- a/server.lua
+++ b/server.lua
@@ -373,9 +373,9 @@ end)
 ---@param metadata { [string]: any }?
 ---@return table | boolean | nil
 lib.callback.register('ox_inventory:useItem', function(source, itemName, slot, metadata, noAnim)
-	local inventory = Inventory(source) --[[@as OxInventory]]
+	local inventory = Inventory(source)
 
-	if inventory.player then
+	if inventory and inventory.player then
 		local item = Items(itemName)
 		local data = item and (slot and inventory.items[slot] or Inventory.GetSlotWithItem(inventory, item.name, metadata, true))
 
@@ -641,6 +641,8 @@ lib.addCommand('clearevidence', {
 	if not server.isPlayerBoss then return end
 
 	local inventory = Inventory(source)
+	if not inventory then return end
+
 	local group, grade = server.hasGroup(inventory, shared.police)
 	local hasPermission = group and server.isPlayerBoss(source, group, grade)
 


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/CommunityOx/ox_inventory/issues/15.

Added nil checks on several places, before accessing values in the `Inventory()` instance.