### PR TITLE
fix: use drop convars for newdrop inventory

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -79,9 +79,9 @@ end
 
 local defaultInventory = {
 	type = 'newdrop',
-	slots = shared.playerslots,
+	slots = shared.dropslots,
 	weight = 0,
-	maxWeight = shared.playerweight,
+	maxWeight = shared.dropweight,
 	items = {}
 }
 

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1557,7 +1557,7 @@ local function dropItem(source, playerInventory, fromData, data)
 	toData.count = data.count
 	toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
 
-    if toData.weight > shared.playerweight then return end
+    if toData.weight > shared.dropweight then return end
 
     local dropId = generateInvId('drop')
 


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/CommunityOx/ox_inventory/issues/17.

New drops created by item swap were using `playerslots` and `playerweight` values instead of `dropslots` and `dropweight`.
This PR fixes it by using the correct values.