### PR TITLE
feat(inventory): add functions to retrieve metadata by slot and items

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -991,6 +991,69 @@ local Utils = require 'modules.utils.server'
 
 ---@param inv inventory
 ---@param slotId number
+---@return table|nil metadata
+function Inventory.GetMetadataWithSlot(inv, slotId)
+    inv = Inventory(inv) --[[@as OxInventory]]
+    local slot = inv and inv.items[slotId]
+
+    if not slot then return end
+
+    return table.clone(slot.metadata)
+end
+exports('GetMetadata', Inventory.GetMetadata)
+
+---@param inv inventory
+---@param itemName string
+---@return table|nil metadata
+function Inventory.GetMetadataWithItem(inv, itemName)
+    inv = Inventory(inv) --[[@as OxInventory]]
+    
+    if not inv then return end
+    
+    for _, slotData in pairs(inv.items) do
+        if slotData and slotData.name == itemName then
+            if not Items.UpdateDurability(inv, slotData, Items(itemName), nil, os.time()) then
+                return table.clone(slotData.metadata)
+            end
+        end
+    end
+end
+exports('GetMetadataWithItem', Inventory.GetMetadataWithItem)
+
+---@param inv inventory
+---@param itemNames string|string[]
+---@return table[]|nil metadata Array of metadata tables with item names included
+function Inventory.GetMetadataWithItems(inv, itemNames)
+    inv = Inventory(inv) --[[@as OxInventory]]
+    
+    if not inv then return end
+    
+    local itemsToFind = type(itemNames) == 'string' and {itemNames} or itemNames
+    local results = {}
+    local n = 0
+    
+    for _, slotData in pairs(inv.items) do
+        if slotData then
+            for _, itemName in ipairs(itemsToFind) do
+                if slotData.name == itemName then
+                    if not Items.UpdateDurability(inv, slotData, Items(itemName), nil, os.time()) then
+                        n += 1
+                        local metadata = table.clone(slotData.metadata)
+                        metadata.name = slotData.name
+                        results[n] = metadata
+                    end
+                    break
+                end
+            end
+        end
+    end
+    
+    return n > 0 and results or nil
+end
+exports('GetMetadataWithItems', Inventory.GetMetadataWithItems)
+
+---@param inv inventory
+---@param slotId number
 ---@param metadata { [string]: any }
 function Inventory.SetMetadata(inv, slotId, metadata)
 	inv = Inventory(inv) --[[@as OxInventory]]


### PR DESCRIPTION
Adds inventory metadata retrieval by slot and item

Enables flexible access to item metadata via slot number or item name(s), supporting advanced inventory queries and integrations. Facilitates external modules or scripts in obtaining up-to-date metadata efficiently.

Examples:

-- Get metadata from specific slot (returns single table or nil)
```lua
    local metadata = exports.ox_inventory:GetMetadataWithItem(source, 'WEAPON_PISTOL')
    print(json.encode(metadata, {indent = true}))

    --[[
        {
            "serial": "306204PUE663350",
            "durability": 95,
            "components": [],
            "registered": "John Doe",
            "ammo": 0
        }
    ]]
```

-- Get metadata for specific item type (returns array or nil)
```lua
    local metadata = exports.ox_inventory:GetMetadata(source, 1)
    print(json.encode(metadata, {indent = true}))
    --[[
        {
            "serial": "306204PUE663350",
            "durability": 95,
            "components": [],
            "registered": "John Doe",
            "ammo": 0
        }
    ]]
```

-- Get metadata for multiple items (returns combined array or nil)
```lua
    local metadata = exports.ox_inventory:GetMetadataWithItems(source, {'WEAPON_PISTOL', 'WEAPON_ADVANCEDRIFLE'})
    print(json.encode(metadata, {indent = true}))
    --[[
    [
        {
            "serial": "306204PUE663350",
            "registered": "John Doe",
            "durability": 95,
            "components": [],
            "name": "WEAPON_PISTOL",
            "ammo": 0
        },
        {
            "serial": "804356XIN972652",
            "registered": "John Doe",
            "durability": 25,
            "components": [],
            "name": "WEAPON_ADVANCEDRIFLE",
            "ammo": 0
        }
    ]
    ]]
```