### PR TITLE
feat(client/server): add player identifier restricted shop items

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -272,6 +272,7 @@ function client.openInventory(inv, data)
     if client.screenblur then TriggerScreenblurFadeIn(0) end
 
     currentInventory = right or defaultInventory
+    left.identifier = PlayerData.identifier
     left.items = PlayerData.inventory
     left.groups = PlayerData.groups
 
@@ -330,6 +331,7 @@ RegisterNetEvent('ox_inventory:forceOpenInventory', function(left, right)
 
 	currentInventory = right or defaultInventory
 	currentInventory.ignoreSecurityChecks = true
+    left.identifier = PlayerData.identifier
 	left.items = PlayerData.inventory
 	left.groups = PlayerData.groups
 
@@ -1187,12 +1189,14 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inven
 	if source == '' then return end
 
     ---@class PlayerData
+    ---@field identifier string
     ---@field inventory table<number, SlotWithItem?>
     ---@field weight number
     ---@field groups table<string, number>
 	PlayerData = player
 	PlayerData.id = cache.playerId
 	PlayerData.source = cache.serverId
+    PlayerData.identifier = player.identifier
     PlayerData.maxWeight = shared.playerweight
 
 	setmetatable(PlayerData, {
@@ -1589,6 +1593,7 @@ RegisterNetEvent('ox_inventory:viewInventory', function(left, right)
 	currentInventory = right or defaultInventory
 	currentInventory.ignoreSecurityChecks = true
     currentInventory.type = 'inspect'
+    left.identifier = PlayerData.identifier
 	left.items = PlayerData.inventory
 	left.groups = PlayerData.groups
 

--- a/data/shops.lua
+++ b/data/shops.lua
@@ -63,7 +63,8 @@ return {
 		blip = {
 			id = 402, colour = 69, scale = 0.8
 		}, inventory = {
-			{ name = 'lockpick', price = 10 }
+			{ name = 'lockpick', price = 10 },
+			{ name = 'lockpick', price = 0, identifiers = {'UED71780', 'citizenid'} } -- only for specific players, use inventory identifier based on framework
 		}, locations = {
 			vec3(2748.0, 3473.0, 55.67),
 			vec3(342.99, -1298.26, 32.51)

--- a/locales/de.json
+++ b/locales/de.json
@@ -63,6 +63,7 @@
   "stash_lowgrade": "Du bist nicht autorisiert diesen Gegenstand zu nehmen",
   "cannot_use": "Du kannst %s nicht benutzen",
   "shop_nostock": "Der Gegenstand ist ausverkauft",
+  "shop_wrongidentifier": "Dieser Gegenstand ist nicht für dich bestimmt.",
   "identification": "Geschlecht: %s  \nGeburtstag: %s",
   "search_dumpster": "Durchsuche Mülleimer",
   "open_label": "Öffne %s",

--- a/locales/en.json
+++ b/locales/en.json
@@ -63,6 +63,7 @@
   "stash_lowgrade": "You are not authorised to take this item",
   "cannot_use": "Unable to use %s",
   "shop_nostock": "Item is out of stock",
+  "shop_wrongidentifier": "This item is not meant for you.",
   "identification": "Sex: %s  \nDate of birth: %s",
   "search_dumpster": "Search Dumpster",
   "open_label": "Open %s",

--- a/modules/bridge/server.lua
+++ b/modules/bridge/server.lua
@@ -17,6 +17,20 @@ function server.hasGroup(inv, group)
 	end
 end
 
+function server.hasIdentifier(inv, identifiers)
+	if type(identifiers) == 'table' then
+		for _, identifier in ipairs(identifiers) do
+			if inv.player.identifier == identifier then
+				return true, identifier
+			end
+		end
+	else
+		return inv.player.identifier == identifiers, identifiers
+	end
+
+	return false, nil
+end
+
 ---@diagnostic disable-next-line: duplicate-set-field
 function server.setPlayerData(player)
 	if not player.groups then

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -33,7 +33,8 @@ local function setupShopItems(id, shopType, shopName, groups)
 				metadata = slot.metadata,
 				license = slot.license,
 				currency = slot.currency,
-				grade = slot.grade
+				grade = slot.grade,
+                identifiers = slot.identifiers,
 			}
 
 			if slot.metadata then
@@ -180,6 +181,20 @@ local function isRequiredGrade(grade, rank)
 	end
 end
 
+local isRequiredIdentifier = function(identifier, identifiers)
+	if type(identifiers) == "table" then
+		for i=1, #identifiers do
+			if identifiers[i] == identifier then
+				return true
+			end
+		end
+		return false
+	else
+		return identifier == identifiers
+	end
+end
+
+
 lib.callback.register('ox_inventory:buyItem', function(source, data)
 	if data.toType == 'player' then
 		if data.count == nil then data.count = 1 end
@@ -215,6 +230,13 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 				local _, rank = server.hasGroup(playerInv, shop.groups)
 				if not isRequiredGrade(fromData.grade, rank) then
 					return false, false, { type = 'error', description = locale('stash_lowgrade') }
+				end
+			end
+
+            if fromData.identifiers then
+				local _, identifier = server.hasIdentifier(playerInv, fromData.identifiers)
+				if not isRequiredIdentifier(identifier, fromData.identifiers) then
+					return false, false, { type = 'error', description = locale('shop_wrongidentifier') }
 				end
 			end
 
@@ -255,6 +277,7 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 					price = fromData.price,
 					totalPrice = price,
 					currency = currency,
+                    identifiers = fromData.identifiers
 				}) then return false end
 
 				Inventory.SetSlot(playerInv, fromItem, count, metadata, data.toSlot)

--- a/server.lua
+++ b/server.lua
@@ -269,7 +269,8 @@ local function openInventory(source, invType, data, ignoreSecurityChecks)
 		type = left.type,
 		slots = left.slots,
 		weight = left.weight,
-		maxWeight = left.maxWeight
+		maxWeight = left.maxWeight,
+        identifier = left.identifier
 	}, right and {
 		id = right.id,
 		label = right.player and '' or right.label,

--- a/web/src/helpers/index.ts
+++ b/web/src/helpers/index.ts
@@ -10,9 +10,20 @@ export const canPurchaseItem = (item: Slot, inventory: { type: Inventory['type']
 
   if (item.count !== undefined && item.count === 0) return false;
 
+  const leftInventory = store.getState().inventory.leftInventory;
+
+  // Item requires specific player identifier but player has not one of them
+  const itemIdentifiers = item.identifiers ?? [];
+  if (itemIdentifiers.length > 0) {
+    const playerIdentifier = leftInventory.identifier ?? '';
+    const itemIds = Array.isArray(itemIdentifiers) ? itemIdentifiers : [itemIdentifiers];
+    const playerIds = Array.isArray(playerIdentifier) ? playerIdentifier : [playerIdentifier];
+
+    if (!playerIds.some((id) => itemIds.includes(id))) return false;
+  }
+
   if (item.grade === undefined || !inventory.groups) return true;
 
-  const leftInventory = store.getState().inventory.leftInventory;
 
   // Shop requires groups but player has none
   if (!leftInventory.groups) return false;

--- a/web/src/typings/inventory.ts
+++ b/web/src/typings/inventory.ts
@@ -15,4 +15,5 @@ export type Inventory = {
   maxWeight?: number;
   label?: string;
   groups?: Record<string, number>;
+  identifier?: string | string[];
 };

--- a/web/src/typings/slot.ts
+++ b/web/src/typings/slot.ts
@@ -20,4 +20,5 @@ export type SlotWithItem = Slot & {
   duration?: number;
   image?: string;
   grade?: number | number[];
+  identifiers?: string | string[];
 };


### PR DESCRIPTION
Hi there,

i wanted to share my integration of restricted shop items based off player identifier.

It should work on every framework if the identifier is set correctly. It currently doesn't support a license or other known identifier, only a framework identifier.

Examples:
- Police vests with first / lastnames on it
- other personalized items

Its also possible to extend this system to allow register shop items in the runtime, allow only specific players (ex. from a job) to buy these items and then delete them again.

I think its a nice feature, even if not everybody needs it.