### PR TITLE
update(client): blur easing and race condition handling

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -269,7 +269,7 @@ function client.openInventory(inv, data)
     SetNuiFocusKeepInput(true)
     closeTrunk()
 
-    if client.screenblur then TriggerScreenblurFadeIn(150) end
+    if client.screenblur then Utils.blurIn() end
 
     currentInventory = right or defaultInventory
     left.items = PlayerData.inventory
@@ -326,7 +326,7 @@ RegisterNetEvent('ox_inventory:forceOpenInventory', function(left, right)
 	SetNuiFocusKeepInput(true)
 	closeTrunk()
 
-	if client.screenblur then TriggerScreenblurFadeIn(150) end
+	if client.screenblur then Utils.blurIn() end
 
 	currentInventory = right or defaultInventory
 	currentInventory.ignoreSecurityChecks = true
@@ -883,8 +883,7 @@ function client.closeInventory(server)
 		invOpen = nil
 		SetNuiFocus(false, false)
 		SetNuiFocusKeepInput(false)
-		if IsScreenblurFadeRunning() then DisableScreenblurFade() end
-		TriggerScreenblurFadeOut(0)
+		Utils.blurOut()
 		closeTrunk()
 		SendNUIMessage({ action = 'closeInventory' })
 		SetInterval(client.interval, 200)
@@ -1585,7 +1584,7 @@ RegisterNetEvent('ox_inventory:viewInventory', function(left, right)
 	SetNuiFocusKeepInput(true)
 	closeTrunk()
 
-	if client.screenblur then TriggerScreenblurFadeIn(150) end
+	if client.screenblur then Utils.blurIn() end
 
 	currentInventory = right or defaultInventory
 	currentInventory.ignoreSecurityChecks = true

--- a/client.lua
+++ b/client.lua
@@ -269,7 +269,7 @@ function client.openInventory(inv, data)
     SetNuiFocusKeepInput(true)
     closeTrunk()
 
-    if client.screenblur then TriggerScreenblurFadeIn(0) end
+    if client.screenblur then TriggerScreenblurFadeIn(150) end
 
     currentInventory = right or defaultInventory
     left.items = PlayerData.inventory
@@ -326,7 +326,7 @@ RegisterNetEvent('ox_inventory:forceOpenInventory', function(left, right)
 	SetNuiFocusKeepInput(true)
 	closeTrunk()
 
-	if client.screenblur then TriggerScreenblurFadeIn(0) end
+	if client.screenblur then TriggerScreenblurFadeIn(150) end
 
 	currentInventory = right or defaultInventory
 	currentInventory.ignoreSecurityChecks = true
@@ -883,6 +883,7 @@ function client.closeInventory(server)
 		invOpen = nil
 		SetNuiFocus(false, false)
 		SetNuiFocusKeepInput(false)
+		if IsScreenblurFadeRunning() then DisableScreenblurFade() end
 		TriggerScreenblurFadeOut(0)
 		closeTrunk()
 		SendNUIMessage({ action = 'closeInventory' })
@@ -1584,7 +1585,7 @@ RegisterNetEvent('ox_inventory:viewInventory', function(left, right)
 	SetNuiFocusKeepInput(true)
 	closeTrunk()
 
-	if client.screenblur then TriggerScreenblurFadeIn(0) end
+	if client.screenblur then TriggerScreenblurFadeIn(150) end
 
 	currentInventory = right or defaultInventory
 	currentInventory.ignoreSecurityChecks = true

--- a/modules/inventory/client.lua
+++ b/modules/inventory/client.lua
@@ -54,6 +54,8 @@ local backDoorIds = { 2, 3 }
 function Inventory.CanAccessTrunk(entity)
     if cache.vehicle or not NetworkGetEntityIsNetworked(entity) then return end
 
+    if GetVehicleEngineHealth(entity) <= 0.0 and GetVehicleBodyHealth(entity) <= 0.0 then return end
+
     local vehicleHash = GetEntityModel(entity)
     local vehicleClass = GetVehicleClass(entity)
     local checkVehicle = Vehicles.Storage[vehicleHash]

--- a/modules/inventory/client.lua
+++ b/modules/inventory/client.lua
@@ -54,8 +54,6 @@ local backDoorIds = { 2, 3 }
 function Inventory.CanAccessTrunk(entity)
     if cache.vehicle or not NetworkGetEntityIsNetworked(entity) then return end
 
-    if GetVehicleEngineHealth(entity) <= 0.0 and GetVehicleBodyHealth(entity) <= 0.0 then return end
-
     local vehicleHash = GetEntityModel(entity)
     local vehicleClass = GetVehicleClass(entity)
     local checkVehicle = Vehicles.Storage[vehicleHash]

--- a/modules/utils/client.lua
+++ b/modules/utils/client.lua
@@ -210,4 +210,21 @@ function Utils.nearbyMarker(point)
     end
 end
 
+function Utils.blurIn()
+    if IsScreenblurFadeRunning() then
+        DisableScreenblurFade()
+    end
+
+    TriggerScreenblurFadeIn(250)
+end
+
+function Utils.blurOut()
+    if IsScreenblurFadeRunning() then
+        DisableScreenblurFade()
+    end
+
+    TriggerScreenblurFadeOut(250)
+end
+
+
 return Utils

--- a/modules/utils/client.lua
+++ b/modules/utils/client.lua
@@ -215,7 +215,7 @@ function Utils.blurIn()
         DisableScreenblurFade()
     end
 
-    TriggerScreenblurFadeIn(250)
+    TriggerScreenblurFadeIn(100)
 end
 
 function Utils.blurOut()


### PR DESCRIPTION
This commit introduces blur fade easing when opening / closing inventory.

inv uses blur, but forces instant fade, which I believe was done because if not handled properly, the blur would remain enabled due to race condition. Added a check on blur out to prevent that behaviour.

