### PR TITLE
fix(inventory): prevent ammo from creating invalid metadata when removed from weapons

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -2620,8 +2620,10 @@ lib.callback.register('ox_inventory:removeAmmoFromWeapon', function(source, slot
 	local item = Items(slotData.name)
 
 	if not item or not item.ammoname then return end
+	local specialAmmo = slotData.metadata.specialAmmo and { type = slotData.metadata.specialAmmo } or nil
 
-	if Inventory.AddItem(inventory, item.ammoname, slotData.metadata.ammo, { type = slotData.metadata.specialAmmo or nil }) then
+
+	if Inventory.AddItem(inventory, item.ammoname, slotData.metadata.ammo, specialAmmo) then
 		slotData.metadata.ammo = 0
 		slotData.weight = Inventory.SlotWeight(item, slotData)
 


### PR DESCRIPTION
Previously, ammo metadata was always passed with type (falsey value if no special ammo present), however table.matches does shallow check, and even if type = nil exists, it will result in mismatch of metadata.

I think this fix is probably slightly better than updating metadata checks, as I think the behaviour is probably predictable as it currently is.

This change ensures that metadata is only passed when a valid `specialAmmo` value
exists, avoiding the creation of `{ type = nil }` and allowing ammo to stack
correctly with existing items.