### PR TITLE
Feat stack limit

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -89,5 +89,6 @@
   "crafting_bench": "Crafting Bench",
   "open_crafting_bench": "Open Crafting Bench",
   "not_enough_durability": "%s does not have enough durability",
-  "storage": "Storage"
+  "storage": "Storage",
+  "stack_full": "You cannot stack more of this item"
 }

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -19,7 +19,8 @@ local function createCraftingBench(id, data)
 				recipe.weight = item.weight
 				recipe.slot = i
 			else
-				warn(('failed to setup crafting recipe (bench: %s, slot: %s) - item "%s" does not exist'):format(id, i, recipe.name))
+				warn(('failed to setup crafting recipe (bench: %s, slot: %s) - item "%s" does not exist'):format(id, i,
+					recipe.name))
 			end
 
 			for ingredient, needs in pairs(recipe.ingredients) do
@@ -112,7 +113,8 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 			end
 
 			local craftedItem = Items(recipe.name)
-			local craftCount = (type(recipe.count) == 'number' and recipe.count) or (table.type(recipe.count) == 'array' and math.random(recipe.count[1], recipe.count[2])) or 1
+			local craftCount = (type(recipe.count) == 'number' and recipe.count) or
+			(table.type(recipe.count) == 'array' and math.random(recipe.count[1], recipe.count[2])) or 1
 
 			-- Modified weight calculation
 			local newWeight = left.weight
@@ -141,7 +143,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 
 				local slots = items[name] or items
 
-                if #slots == 0 then return end
+				if #slots == 0 then return end
 
 				for i = 1, #slots do
 					local slot = slots[i]
@@ -183,13 +185,15 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 			end
 
 			if not TriggerEventHooks('craftItem', {
-				source = source,
-				benchId = id,
-				benchIndex = index,
-				recipe = recipe,
-				toInventory = left.id,
-				toSlot = toSlot,
-			}) then return false end
+					source = source,
+					benchId = id,
+					benchIndex = index,
+					recipe = recipe,
+					toInventory = left.id,
+					toSlot = toSlot,
+				}) then
+				return false
+			end
 
 			local success = lib.callback.await('ox_inventory:startCrafting', source, id, recipeId)
 
@@ -218,15 +222,16 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 							local emptySlot = Inventory.GetEmptySlot(left)
 
 							if emptySlot then
-								local newItem = Inventory.SetSlot(left, item, 1, table.deepclone(invSlot.metadata), emptySlot)
+								local newItem = Inventory.SetSlot(left, item, 1, table.deepclone(invSlot.metadata),
+									emptySlot)
 
 								if newItem then
-                                    Items.UpdateDurability(left, newItem, item, durability < 0 and 0 or durability)
+									Items.UpdateDurability(left, newItem, item, durability < 0 and 0 or durability)
 								end
 							end
 
 							invSlot.count -= 1
-                            invSlot.weight = Inventory.SlotWeight(item, invSlot)
+							invSlot.weight = Inventory.SlotWeight(item, invSlot)
 
 							left:syncSlotsWithClients({
 								{
@@ -235,7 +240,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 								}
 							}, true)
 						else
-                            Items.UpdateDurability(left, invSlot, item, durability < 0 and 0 or durability)
+							Items.UpdateDurability(left, invSlot, item, durability < 0 and 0 or durability)
 						end
 					else
 						local removed = invSlot and Inventory.RemoveItem(left, invSlot.name, count, nil, slot)
@@ -244,7 +249,8 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 					end
 				end
 
-				Inventory.AddItem(left, craftedItem, craftCount, recipe.metadata or {}, craftedItem.stack and toSlot or nil)
+				Inventory.AddItem(left, craftedItem, craftCount, recipe.metadata or {},
+					craftedItem.stack and toSlot or nil)
 			end
 
 			return success

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -7,41 +7,41 @@ local Inventory = require 'modules.inventory.server'
 ---@param id number
 ---@param data table
 local function createCraftingBench(id, data)
-	CraftingBenches[id] = {}
-	local recipes = data.items
+    CraftingBenches[id] = {}
+    local recipes = data.items
 
-	if recipes then
-		for i = 1, #recipes do
-			local recipe = recipes[i]
-			local item = Items(recipe.name)
+    if recipes then
+        for i = 1, #recipes do
+            local recipe = recipes[i]
+            local item = Items(recipe.name)
 
-			if item then
-				recipe.weight = item.weight
-				recipe.slot = i
-			else
-				warn(('failed to setup crafting recipe (bench: %s, slot: %s) - item "%s" does not exist'):format(id, i,
-					recipe.name))
-			end
+            if item then
+                recipe.weight = item.weight
+                recipe.slot = i
+            else
+                warn(('failed to setup crafting recipe (bench: %s, slot: %s) - item "%s" does not exist'):format(id, i,
+                    recipe.name))
+            end
 
-			for ingredient, needs in pairs(recipe.ingredients) do
-				if needs < 1 then
-					item = Items(ingredient)
+            for ingredient, needs in pairs(recipe.ingredients) do
+                if needs < 1 then
+                    item = Items(ingredient)
 
-					if item and not item.durability then
-						item.durability = true
-					end
-				end
-			end
-		end
+                    if item and not item.durability then
+                        item.durability = true
+                    end
+                end
+            end
+        end
 
-		if shared.target then
-			data.points = nil
-		else
-			data.zones = nil
-		end
+        if shared.target then
+            data.points = nil
+        else
+            data.zones = nil
+        end
 
-		CraftingBenches[id] = data
-	end
+        CraftingBenches[id] = data
+    end
 end
 
 for id, data in pairs(lib.load('data.crafting') or {}) do createCraftingBench(data.name or id, data) end
@@ -52,208 +52,208 @@ for id, data in pairs(lib.load('data.crafting') or {}) do createCraftingBench(da
 ---@param index number
 ---@return vector3
 local function getCraftingCoords(source, bench, index)
-	if not bench.zones and not bench.points then
-		return GetEntityCoords(GetPlayerPed(source))
-	else
-		return shared.target and bench.zones[index].coords or bench.points[index]
-	end
+    if not bench.zones and not bench.points then
+        return GetEntityCoords(GetPlayerPed(source))
+    else
+        return shared.target and bench.zones[index].coords or bench.points[index]
+    end
 end
 
 lib.callback.register('ox_inventory:openCraftingBench', function(source, id, index)
-	local left, bench = Inventory(source), CraftingBenches[id]
+    local left, bench = Inventory(source), CraftingBenches[id]
 
-	if not left then return end
+    if not left then return end
 
-	if bench then
-		local groups = bench.groups
-		local coords = getCraftingCoords(source, bench, index)
+    if bench then
+        local groups = bench.groups
+        local coords = getCraftingCoords(source, bench, index)
 
-		if not coords then return end
+        if not coords then return end
 
-		if groups and not server.hasGroup(left, groups) then return end
-		if #(GetEntityCoords(GetPlayerPed(source)) - coords) > 10 then return end
+        if groups and not server.hasGroup(left, groups) then return end
+        if #(GetEntityCoords(GetPlayerPed(source)) - coords) > 10 then return end
 
-		if left.open and left.open ~= source then
-			local inv = Inventory(left.open) --[[@as OxInventory]]
+        if left.open and left.open ~= source then
+            local inv = Inventory(left.open) --[[@as OxInventory]]
 
-			-- Why would the player inventory open with an invalid target? Can't repro but whatever.
-			if inv?.player then
-				inv:closeInventory()
-			end
-		end
+            -- Why would the player inventory open with an invalid target? Can't repro but whatever.
+            if inv?.player then
+                inv:closeInventory()
+            end
+        end
 
-		left:openInventory(left)
-	end
+        left:openInventory(left)
+    end
 
-	return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight }
+    return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight }
 end)
 
 local TriggerEventHooks = require 'modules.hooks.server'
 
 lib.callback.register('ox_inventory:craftItem', function(source, id, index, recipeId, toSlot)
-	local left, bench = Inventory(source), CraftingBenches[id]
+    local left, bench = Inventory(source), CraftingBenches[id]
 
-	if not left then return end
+    if not left then return end
 
-	if bench then
-		local groups = bench.groups
-		local coords = getCraftingCoords(source, bench, index)
+    if bench then
+        local groups = bench.groups
+        local coords = getCraftingCoords(source, bench, index)
 
-		if groups and not server.hasGroup(left, groups) then return end
-		if #(GetEntityCoords(GetPlayerPed(source)) - coords) > 10 then return end
+        if groups and not server.hasGroup(left, groups) then return end
+        if #(GetEntityCoords(GetPlayerPed(source)) - coords) > 10 then return end
 
-		local recipe = bench.items[recipeId]
+        local recipe = bench.items[recipeId]
 
-		if recipe then
-			local tbl, num = {}, 0
+        if recipe then
+            local tbl, num = {}, 0
 
-			for name in pairs(recipe.ingredients) do
-				num += 1
-				tbl[num] = name
-			end
+            for name in pairs(recipe.ingredients) do
+                num += 1
+                tbl[num] = name
+            end
 
-			local craftedItem = Items(recipe.name)
-			local craftCount = (type(recipe.count) == 'number' and recipe.count) or
-			(table.type(recipe.count) == 'array' and math.random(recipe.count[1], recipe.count[2])) or 1
+            local craftedItem = Items(recipe.name)
+            local craftCount = (type(recipe.count) == 'number' and recipe.count) or
+                (table.type(recipe.count) == 'array' and math.random(recipe.count[1], recipe.count[2])) or 1
 
-			-- Modified weight calculation
-			local newWeight = left.weight
-			local items = Inventory.Search(left, 'slots', tbl) or {}
-			---@todo new iterator or something to accept a map
-			-- First subtract weight of ingredients that will be removed
-			for name, needs in pairs(recipe.ingredients) do
-				if needs > 0 then
-					local item = Items(name)
-					if item then
-						newWeight -= (item.weight * needs)
-					end
-				end
-			end
+            -- Modified weight calculation
+            local newWeight = left.weight
+            local items = Inventory.Search(left, 'slots', tbl) or {}
+            ---@todo new iterator or something to accept a map
+            -- First subtract weight of ingredients that will be removed
+            for name, needs in pairs(recipe.ingredients) do
+                if needs > 0 then
+                    local item = Items(name)
+                    if item then
+                        newWeight -= (item.weight * needs)
+                    end
+                end
+            end
 
-			-- Add weight of crafted item
-			newWeight += (craftedItem.weight + (recipe.metadata?.weight or 0)) * craftCount
+            -- Add weight of crafted item
+            newWeight += (craftedItem.weight + (recipe.metadata?.weight or 0)) * craftCount
 
-			if newWeight > left.maxWeight then return false, 'cannot_carry' end
+            if newWeight > left.maxWeight then return false, 'cannot_carry' end
 
-			local items = Inventory.Search(left, 'slots', tbl) or {}
-			table.wipe(tbl)
+            local items = Inventory.Search(left, 'slots', tbl) or {}
+            table.wipe(tbl)
 
-			for name, needs in pairs(recipe.ingredients) do
-				if needs == 0 then break end
+            for name, needs in pairs(recipe.ingredients) do
+                if needs == 0 then break end
 
-				local slots = items[name] or items
+                local slots = items[name] or items
 
-				if #slots == 0 then return end
+                if #slots == 0 then return end
 
-				for i = 1, #slots do
-					local slot = slots[i]
+                for i = 1, #slots do
+                    local slot = slots[i]
 
-					if needs == 0 then
-						if not slot.metadata.durability or slot.metadata.durability > 0 then
-							break
-						end
-					elseif needs < 1 then
-						local item = Items(name)
-						local durability = slot.metadata.durability
+                    if needs == 0 then
+                        if not slot.metadata.durability or slot.metadata.durability > 0 then
+                            break
+                        end
+                    elseif needs < 1 then
+                        local item = Items(name)
+                        local durability = slot.metadata.durability
 
-						if durability and durability >= needs * 100 then
-							if durability > 100 then
-								local degrade = (slot.metadata.degrade or item.degrade) * 60
-								local percentage = ((durability - os.time()) * 100) / degrade
+                        if durability and durability >= needs * 100 then
+                            if durability > 100 then
+                                local degrade = (slot.metadata.degrade or item.degrade) * 60
+                                local percentage = ((durability - os.time()) * 100) / degrade
 
-								if percentage >= needs * 100 then
-									tbl[slot.slot] = needs
-									break
-								end
-							else
-								tbl[slot.slot] = needs
-								break
-							end
-						end
-					elseif needs <= slot.count then
-						tbl[slot.slot] = needs
-						break
-					else
-						tbl[slot.slot] = slot.count
-						needs -= slot.count
-					end
+                                if percentage >= needs * 100 then
+                                    tbl[slot.slot] = needs
+                                    break
+                                end
+                            else
+                                tbl[slot.slot] = needs
+                                break
+                            end
+                        end
+                    elseif needs <= slot.count then
+                        tbl[slot.slot] = needs
+                        break
+                    else
+                        tbl[slot.slot] = slot.count
+                        needs -= slot.count
+                    end
 
-					if needs == 0 then break end
-					-- Player does not have enough items (ui should prevent crafting if lacking items, so this shouldn't trigger)
-					if needs > 0 and i == #slots then return end
-				end
-			end
+                    if needs == 0 then break end
+                    -- Player does not have enough items (ui should prevent crafting if lacking items, so this shouldn't trigger)
+                    if needs > 0 and i == #slots then return end
+                end
+            end
 
-			if not TriggerEventHooks('craftItem', {
-					source = source,
-					benchId = id,
-					benchIndex = index,
-					recipe = recipe,
-					toInventory = left.id,
-					toSlot = toSlot,
-				}) then
-				return false
-			end
+            if not TriggerEventHooks('craftItem', {
+                    source = source,
+                    benchId = id,
+                    benchIndex = index,
+                    recipe = recipe,
+                    toInventory = left.id,
+                    toSlot = toSlot,
+                }) then
+                return false
+            end
 
-			local success = lib.callback.await('ox_inventory:startCrafting', source, id, recipeId)
+            local success = lib.callback.await('ox_inventory:startCrafting', source, id, recipeId)
 
-			if success then
-				for name, needs in pairs(recipe.ingredients) do
-					if Inventory.GetItemCount(left, name) < needs then return end
-				end
+            if success then
+                for name, needs in pairs(recipe.ingredients) do
+                    if Inventory.GetItemCount(left, name) < needs then return end
+                end
 
-				for slot, count in pairs(tbl) do
-					local invSlot = left.items[slot]
+                for slot, count in pairs(tbl) do
+                    local invSlot = left.items[slot]
 
-					if not invSlot then return end
+                    if not invSlot then return end
 
-					if count < 1 then
-						local item = Items(invSlot.name)
-						local durability = invSlot.metadata.durability or 100
+                    if count < 1 then
+                        local item = Items(invSlot.name)
+                        local durability = invSlot.metadata.durability or 100
 
-						if durability > 100 then
-							local degrade = (invSlot.metadata.degrade or item.degrade) * 60
-							durability -= degrade * count
-						else
-							durability -= count * 100
-						end
+                        if durability > 100 then
+                            local degrade = (invSlot.metadata.degrade or item.degrade) * 60
+                            durability -= degrade * count
+                        else
+                            durability -= count * 100
+                        end
 
-						if invSlot.count > 1 then
-							local emptySlot = Inventory.GetEmptySlot(left)
+                        if invSlot.count > 1 then
+                            local emptySlot = Inventory.GetEmptySlot(left)
 
-							if emptySlot then
-								local newItem = Inventory.SetSlot(left, item, 1, table.deepclone(invSlot.metadata),
-									emptySlot)
+                            if emptySlot then
+                                local newItem = Inventory.SetSlot(left, item, 1, table.deepclone(invSlot.metadata),
+                                    emptySlot)
 
-								if newItem then
-									Items.UpdateDurability(left, newItem, item, durability < 0 and 0 or durability)
-								end
-							end
+                                if newItem then
+                                    Items.UpdateDurability(left, newItem, item, durability < 0 and 0 or durability)
+                                end
+                            end
 
-							invSlot.count -= 1
-							invSlot.weight = Inventory.SlotWeight(item, invSlot)
+                            invSlot.count -= 1
+                            invSlot.weight = Inventory.SlotWeight(item, invSlot)
 
-							left:syncSlotsWithClients({
-								{
-									item = invSlot,
-									inventory = left.id
-								}
-							}, true)
-						else
-							Items.UpdateDurability(left, invSlot, item, durability < 0 and 0 or durability)
-						end
-					else
-						local removed = invSlot and Inventory.RemoveItem(left, invSlot.name, count, nil, slot)
-						-- Failed to remove item (inventory state unexpectedly changed?)
-						if not removed then return end
-					end
-				end
+                            left:syncSlotsWithClients({
+                                {
+                                    item = invSlot,
+                                    inventory = left.id
+                                }
+                            }, true)
+                        else
+                            Items.UpdateDurability(left, invSlot, item, durability < 0 and 0 or durability)
+                        end
+                    else
+                        local removed = invSlot and Inventory.RemoveItem(left, invSlot.name, count, nil, slot)
+                        -- Failed to remove item (inventory state unexpectedly changed?)
+                        if not removed then return end
+                    end
+                end
 
-				Inventory.AddItem(left, craftedItem, craftCount, recipe.metadata or {},
-					craftedItem.stack and toSlot or nil)
-			end
+                Inventory.AddItem(left, craftedItem, craftCount, recipe.metadata or {},
+                    craftedItem.stack and toSlot or nil)
+            end
 
-			return success
-		end
-	end
+            return success
+        end
+    end
 end)

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -12,39 +12,39 @@ OxInventory.__index = OxInventory
 ---Open a player's inventory, optionally with a secondary inventory.
 ---@param inv? inventory
 function OxInventory:openInventory(inv)
-    if not self?.player then return end
+	if not self?.player then return end
 
-    inv = Inventory(inv)
+	inv = Inventory(inv)
 
-    if not inv then return end
+	if not inv then return end
 
-    inv:set('open', true)
-    inv.openedBy[self.id] = true
-    self.open = inv.id
+	inv:set('open', true)
+	inv.openedBy[self.id] = true
+	self.open = inv.id
 
-    TriggerEvent('ox_inventory:openedInventory', self.id, inv.id)
+	TriggerEvent('ox_inventory:openedInventory', self.id, inv.id)
 end
 
 ---Close a player's inventory.
 ---@param noEvent? boolean
 function OxInventory:closeInventory(noEvent)
-    if not self.player or not self.open then return end
+	if not self.player or not self.open then return end
 
-    local inv = Inventory(self.open)
+	local inv = Inventory(self.open)
 
-    if not inv then return end
+	if not inv then return end
 
-    inv.openedBy[self.id] = nil
-    inv:set('open', false)
-    self.open = false
-    self.currentShop = nil
-    self.containerSlot = nil
+	inv.openedBy[self.id] = nil
+	inv:set('open', false)
+	self.open = false
+	self.currentShop = nil
+	self.containerSlot = nil
 
-    if not noEvent then
-        TriggerClientEvent('ox_inventory:closeInventory', self.id, true)
-    end
+	if not noEvent then
+		TriggerClientEvent('ox_inventory:closeInventory', self.id, true)
+	end
 
-    TriggerEvent('ox_inventory:closedInventory', self.id, inv.id)
+	TriggerEvent('ox_inventory:closedInventory', self.id, inv.id)
 end
 
 ---@alias updateSlot { item: SlotWithItem | { slot: number }, inventory: string|number }
@@ -53,42 +53,42 @@ end
 ---@param slots updateSlot[]
 ---@param weight { left?: number, right?: number } | number
 function OxInventory:syncSlotsWithPlayer(slots, weight)
-    TriggerClientEvent('ox_inventory:updateSlots', self.id, slots, weight)
+	TriggerClientEvent('ox_inventory:updateSlots', self.id, slots, weight)
 end
 
 ---Sync an inventory's state with all player's accessing it.
 ---@param slots updateSlot[]
 ---@param syncOwner? boolean
 function OxInventory:syncSlotsWithClients(slots, syncOwner)
-    for playerId in pairs(self.openedBy) do
-        if self.id ~= playerId then
-            local target = Inventories[playerId]
+	for playerId in pairs(self.openedBy) do
+		if self.id ~= playerId then
+			local target = Inventories[playerId]
 
-            if target then
-                TriggerClientEvent('ox_inventory:updateSlots', playerId, slots, target.weight)
-            end
-        end
-    end
+			if target then
+				TriggerClientEvent('ox_inventory:updateSlots', playerId, slots, target.weight)
+			end
+		end
+	end
 
-    if syncOwner and self.player then
-        TriggerClientEvent('ox_inventory:updateSlots', self.id, slots, self.weight)
-    end
+	if syncOwner and self.player then
+		TriggerClientEvent('ox_inventory:updateSlots', self.id, slots, self.weight)
+	end
 end
 
 local Vehicles = lib.load('data.vehicles')
 local RegisteredStashes = {}
 
 for _, stash in pairs(lib.load('data.stashes') or {}) do
-    RegisteredStashes[stash.name] = {
-        name = stash.name,
-        label = stash.label,
-        owner = stash.owner,
-        slots = stash.slots,
-        maxWeight = stash.weight,
-        groups = stash.groups or stash.jobs,
-        coords = shared.target and stash.target?.loc or stash.coords,
-        distance = stash.distance or 10
-    }
+	RegisteredStashes[stash.name] = {
+		name = stash.name,
+		label = stash.label,
+		owner = stash.owner,
+		slots = stash.slots,
+		maxWeight = stash.weight,
+		groups = stash.groups or stash.jobs,
+		coords = shared.target and stash.target?.loc or stash.coords,
+		distance = stash.distance or 10
+	}
 end
 
 local GetVehicleNumberPlateText = GetVehicleNumberPlateText
@@ -99,132 +99,132 @@ local GetVehicleNumberPlateText = GetVehicleNumberPlateText
 ---@param ignoreSecurityChecks boolean
 ---@return OxInventory | false | nil
 local function loadInventoryData(data, player, ignoreSecurityChecks)
-    local source = source
-    local inventory
+	local source = source
+	local inventory
 
-    if not data.type and type(data.id) == 'string' then
-        if data.id:find('^glove') then
-            data.type = 'glovebox'
-        elseif data.id:find('^trunk') then
-            data.type = 'trunk'
-        elseif data.id:find('^evidence-') then
-            data.type = 'policeevidence'
-        end
-    end
+	if not data.type and type(data.id) == 'string' then
+		if data.id:find('^glove') then
+			data.type = 'glovebox'
+		elseif data.id:find('^trunk') then
+			data.type = 'trunk'
+		elseif data.id:find('^evidence-') then
+			data.type = 'policeevidence'
+		end
+	end
 
-    if data.type == 'trunk' or data.type == 'glovebox' then
-        local plate = data.id:sub(6)
+	if data.type == 'trunk' or data.type == 'glovebox' then
+		local plate = data.id:sub(6)
 
-        if server.trimplate then
-            plate = string.strtrim(plate)
-            data.id = ('%s%s'):format(data.id:sub(1, 5), plate)
-        end
+		if server.trimplate then
+			plate = string.strtrim(plate)
+			data.id = ('%s%s'):format(data.id:sub(1, 5), plate)
+		end
 
-        inventory = Inventories[data.id]
+		inventory = Inventories[data.id]
 
-        if not inventory then
-            local entity
+		if not inventory then
+			local entity
 
-            if data.netid then
-                entity = NetworkGetEntityFromNetworkId(data.netid)
+			if data.netid then
+				entity = NetworkGetEntityFromNetworkId(data.netid)
 
-                if not entity then
-                    return shared.info('Failed to load vehicle inventory data (no entity exists with given netid).')
-                end
+				if not entity then
+					return shared.info('Failed to load vehicle inventory data (no entity exists with given netid).')
+				end
 
-                data.entityId = entity
-            else
-                local vehicles = GetAllVehicles()
+				data.entityId = entity
+			else
+				local vehicles = GetAllVehicles()
 
-                for i = 1, #vehicles do
-                    local vehicle = vehicles[i]
-                    local _plate = GetVehicleNumberPlateText(vehicle)
+				for i = 1, #vehicles do
+					local vehicle = vehicles[i]
+					local _plate = GetVehicleNumberPlateText(vehicle)
 
-                    if _plate:find(plate) then
-                        entity = vehicle
-                        data.entityId = entity
-                        data.netid = NetworkGetNetworkIdFromEntity(entity)
-                        break
-                    end
-                end
+					if _plate:find(plate) then
+						entity = vehicle
+						data.entityId = entity
+						data.netid = NetworkGetNetworkIdFromEntity(entity)
+						break
+					end
+				end
 
-                if not entity then
-                    return shared.info('Failed to load vehicle inventory data (no entity exists with given plate).')
-                end
-            end
+				if not entity then
+					return shared.info('Failed to load vehicle inventory data (no entity exists with given plate).')
+				end
+			end
 
-            if not source then
-                source = NetworkGetEntityOwner(entity)
+			if not source then
+				source = NetworkGetEntityOwner(entity)
 
-                if not source then
-                    return shared.info('Failed to load vehicle inventory data (entity is unowned).')
-                end
-            end
+				if not source then
+					return shared.info('Failed to load vehicle inventory data (entity is unowned).')
+				end
+			end
 
-            local model, class = lib.callback.await('ox_inventory:getVehicleData', source, data.netid)
-            local storage = Vehicles[data.type].models[model] or Vehicles[data.type][class]
-            local dbId
+			local model, class = lib.callback.await('ox_inventory:getVehicleData', source, data.netid)
+			local storage = Vehicles[data.type].models[model] or Vehicles[data.type][class]
+			local dbId
 
-            if server.getOwnedVehicleId then
-                dbId = server.getOwnedVehicleId(entity)
-            else
-                dbId = data.id:sub(6)
-            end
+			if server.getOwnedVehicleId then
+				dbId = server.getOwnedVehicleId(entity)
+			else
+				dbId = data.id:sub(6)
+			end
 
-            inventory = Inventory.Create(data.id, plate, data.type, storage[1], 0, storage[2], false, nil, nil, dbId)
-        end
-    elseif data.type == 'policeevidence' then
-        inventory = Inventory.Create(data.id, locale('police_evidence'), data.type, 100, 0, 100000, false)
-    else
-        local stash = RegisteredStashes[data.id]
+			inventory = Inventory.Create(data.id, plate, data.type, storage[1], 0, storage[2], false, nil, nil, dbId)
+		end
+	elseif data.type == 'policeevidence' then
+		inventory = Inventory.Create(data.id, locale('police_evidence'), data.type, 100, 0, 100000, false)
+	else
+		local stash = RegisteredStashes[data.id]
 
-        if stash then
-            if stash.jobs then stash.groups = stash.jobs end
-            if not ignoreSecurityChecks and player and stash.groups and not server.hasGroup(player, stash.groups) then return end
+		if stash then
+			if stash.jobs then stash.groups = stash.jobs end
+			if not ignoreSecurityChecks and player and stash.groups and not server.hasGroup(player, stash.groups) then return end
 
-            local owner
+			local owner
 
-            if stash.owner then
-                if stash.owner == true then
-                    owner = data.owner or player?.owner
-                else
-                    owner = stash.owner
-                end
-            end
+			if stash.owner then
+				if stash.owner == true then
+					owner = data.owner or player?.owner
+				else
+					owner = stash.owner
+				end
+			end
 
-            inventory = Inventories[owner and ('%s:%s'):format(stash.name, owner) or stash.name]
+			inventory = Inventories[owner and ('%s:%s'):format(stash.name, owner) or stash.name]
 
-            if not inventory then
-                inventory = Inventory.Create(stash.name, stash.label or stash.name, 'stash', stash.slots, 0,
-                    stash.maxWeight, owner, nil, stash.groups)
-                inventory.coords = stash.coords
-                inventory.distance = stash.distance
-            end
-        end
-    end
+			if not inventory then
+				inventory = Inventory.Create(stash.name, stash.label or stash.name, 'stash', stash.slots, 0,
+					stash.maxWeight, owner, nil, stash.groups)
+				inventory.coords = stash.coords
+				inventory.distance = stash.distance
+			end
+		end
+	end
 
-    if data.netid then
-        inventory.entityId = data.entityId or NetworkGetEntityFromNetworkId(data.netid)
-        inventory.netid = data.netid
-    end
+	if data.netid then
+		inventory.entityId = data.entityId or NetworkGetEntityFromNetworkId(data.netid)
+		inventory.netid = data.netid
+	end
 
-    return inventory or false
+	return inventory or false
 end
 
 setmetatable(Inventory, {
-    __call = function(self, inv, player, ignoreSecurityChecks)
-        if Inventory.Lock then return false end
+	__call = function(self, inv, player, ignoreSecurityChecks)
+		if Inventory.Lock then return false end
 
-        if not inv then
-            return self
-        elseif type(inv) == 'table' then
-            if inv.__index then return inv end
+		if not inv then
+			return self
+		elseif type(inv) == 'table' then
+			if inv.__index then return inv end
 
-            return not inv.owner and Inventories[inv.id] or loadInventoryData(inv, player, ignoreSecurityChecks)
-        end
+			return not inv.owner and Inventories[inv.id] or loadInventoryData(inv, player, ignoreSecurityChecks)
+		end
 
-        return Inventories[inv] or loadInventoryData({ id = inv }, player, ignoreSecurityChecks)
-    end
+		return Inventories[inv] or loadInventoryData({ id = inv }, player, ignoreSecurityChecks)
+	end
 })
 
 ---@cast Inventory +fun(inv: inventory, player?: inventory, ignoreSecurityChecks?: boolean): OxInventory|false|nil
@@ -232,15 +232,15 @@ setmetatable(Inventory, {
 ---@param inv inventory
 ---@param owner? string | number
 local function getInventory(inv, owner)
-    if not inv then return Inventory end
+	if not inv then return Inventory end
 
-    local type = type(inv)
+	local type = type(inv)
 
-    if type == 'table' or type == 'number' then
-        return Inventory(inv)
-    else
-        return Inventory({ id = inv, owner = owner })
-    end
+	if type == 'table' or type == 'number' then
+		return Inventory(inv)
+	else
+		return Inventory({ id = inv, owner = owner })
+	end
 end
 
 exports('Inventory', getInventory)
@@ -250,26 +250,26 @@ exports('GetInventory', getInventory)
 ---@param owner? string | number
 ---@return table?
 exports('GetInventoryItems', function(inv, owner)
-    return getInventory(inv, owner)?.items
+	return getInventory(inv, owner)?.items
 end)
 
 ---@param inv inventory
 ---@param slotId number
 ---@return OxInventory?
 function Inventory.GetContainerFromSlot(inv, slotId)
-    local inventory = Inventory(inv)
-    local slotData = inventory and inventory.items[slotId]
+	local inventory = Inventory(inv)
+	local slotData = inventory and inventory.items[slotId]
 
-    if not slotData then return end
+	if not slotData then return end
 
-    local container = Inventory(slotData.metadata.container)
+	local container = Inventory(slotData.metadata.container)
 
-    if not container then
-        container = Inventory.Create(slotData.metadata.container, slotData.label, 'container', slotData.metadata.size[1],
-            0, slotData.metadata.size[2], false)
-    end
+	if not container then
+		container = Inventory.Create(slotData.metadata.container, slotData.label, 'container', slotData.metadata.size[1],
+			0, slotData.metadata.size[2], false)
+	end
 
-    return container
+	return container
 end
 
 exports('GetContainerFromSlot', Inventory.GetContainerFromSlot)
@@ -277,71 +277,71 @@ exports('GetContainerFromSlot', Inventory.GetContainerFromSlot)
 ---@param inv? inventory
 ---@param ignoreId? number|false
 function Inventory.CloseAll(inv, ignoreId)
-    if not inv then
-        for _, data in pairs(Inventories) do
-            for playerId in pairs(data.openedBy) do
-                local playerInv = Inventory(playerId)
+	if not inv then
+		for _, data in pairs(Inventories) do
+			for playerId in pairs(data.openedBy) do
+				local playerInv = Inventory(playerId)
 
-                if playerInv then playerInv:closeInventory(true) end
-            end
-        end
+				if playerInv then playerInv:closeInventory(true) end
+			end
+		end
 
-        return TriggerClientEvent('ox_inventory:closeInventory', -1, true)
-    end
+		return TriggerClientEvent('ox_inventory:closeInventory', -1, true)
+	end
 
-    inv = Inventory(inv) --[[@as OxInventory?]]
+	inv = Inventory(inv) --[[@as OxInventory?]]
 
-    if not inv then return end
+	if not inv then return end
 
-    for playerId in pairs(inv.openedBy) do
-        local playerInv = Inventory(playerId)
+	for playerId in pairs(inv.openedBy) do
+		local playerInv = Inventory(playerId)
 
-        if playerInv and playerId ~= ignoreId then
-            playerInv:closeInventory()
-        end
-    end
+		if playerInv and playerId ~= ignoreId then
+			playerInv:closeInventory()
+		end
+	end
 end
 
 ---@param inv inventory
 ---@param k string
 ---@param v any
 function Inventory.Set(inv, k, v)
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if inv then
-        if type(v) == 'number' then
-            v = math.floor(v + 0.5)
-        end
+	if inv then
+		if type(v) == 'number' then
+			v = math.floor(v + 0.5)
+		end
 
-        if k == 'open' and v == false then
-            if inv.type ~= 'player' then
-                if inv.player then
-                    inv.type = 'player'
-                elseif inv.type == 'drop' and not next(inv.items) and not next(inv.openedBy) then
-                    return Inventory.Remove(inv)
-                else
-                    inv.time = os.time()
-                end
-            end
+		if k == 'open' and v == false then
+			if inv.type ~= 'player' then
+				if inv.player then
+					inv.type = 'player'
+				elseif inv.type == 'drop' and not next(inv.items) and not next(inv.openedBy) then
+					return Inventory.Remove(inv)
+				else
+					inv.time = os.time()
+				end
+			end
 
-            if inv.player then
-                inv.containerSlot = nil
-            end
-        elseif k == 'maxWeight' and v < 1000 then
-            v *= 1000
-        end
+			if inv.player then
+				inv.containerSlot = nil
+			end
+		elseif k == 'maxWeight' and v < 1000 then
+			v *= 1000
+		end
 
-        inv[k] = v
-    end
+		inv[k] = v
+	end
 end
 
 ---@param inv inventory
 ---@param key string
 function Inventory.Get(inv, key)
-    inv = Inventory(inv) --[[@as OxInventory]]
-    if inv then
-        return inv[key]
-    end
+	inv = Inventory(inv) --[[@as OxInventory]]
+	if inv then
+		return inv[key]
+	end
 end
 
 ---@class MinimalInventorySlot
@@ -353,20 +353,20 @@ end
 ---@param inv inventory
 ---@return MinimalInventorySlot[] items
 local function minimal(inv)
-    inv = Inventory(inv) --[[@as OxInventory]]
-    local inventory, count = {}, 0
-    for k, v in pairs(inv.items) do
-        if v.name and v.count > 0 then
-            count += 1
-            inventory[count] = {
-                name = v.name,
-                count = v.count,
-                slot = k,
-                metadata = next(v.metadata) and v.metadata or nil
-            }
-        end
-    end
-    return inventory
+	inv = Inventory(inv) --[[@as OxInventory]]
+	local inventory, count = {}, 0
+	for k, v in pairs(inv.items) do
+		if v.name and v.count > 0 then
+			count += 1
+			inventory[count] = {
+				name = v.name,
+				count = v.count,
+				slot = k,
+				metadata = next(v.metadata) and v.metadata or nil
+			}
+		end
+	end
+	return inventory
 end
 
 ---@param inv inventory
@@ -375,196 +375,196 @@ end
 ---@param metadata any
 ---@param slot any
 function Inventory.SetSlot(inv, item, count, metadata, slot)
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if not inv then return end
+	if not inv then return end
 
-    local currentSlot = inv.items[slot]
-    local newCount = currentSlot and currentSlot.count + count or count
-    local newWeight = currentSlot and inv.weight - currentSlot.weight or inv.weight
+	local currentSlot = inv.items[slot]
+	local newCount = currentSlot and currentSlot.count + count or count
+	local newWeight = currentSlot and inv.weight - currentSlot.weight or inv.weight
 
-    if currentSlot and newCount < 1 then
-        TriggerClientEvent('ox_inventory:itemNotify', inv.id, { currentSlot, 'ui_removed', currentSlot.count })
-        currentSlot = nil
-    else
-        currentSlot = {
-            name = item.name,
-            label = item.label,
-            weight = item.weight,
-            slot = slot,
-            count = newCount,
-            description = item.description,
-            metadata = metadata,
-            stack = item.stack,
-            close = item.close
-        }
-        local slotWeight = Inventory.SlotWeight(item, currentSlot)
-        currentSlot.weight = slotWeight
-        newWeight += slotWeight
+	if currentSlot and newCount < 1 then
+		TriggerClientEvent('ox_inventory:itemNotify', inv.id, { currentSlot, 'ui_removed', currentSlot.count })
+		currentSlot = nil
+	else
+		currentSlot = {
+			name = item.name,
+			label = item.label,
+			weight = item.weight,
+			slot = slot,
+			count = newCount,
+			description = item.description,
+			metadata = metadata,
+			stack = item.stack,
+			close = item.close
+		}
+		local slotWeight = Inventory.SlotWeight(item, currentSlot)
+		currentSlot.weight = slotWeight
+		newWeight += slotWeight
 
-        TriggerClientEvent('ox_inventory:itemNotify', inv.id,
-            { currentSlot, count < 0 and 'ui_removed' or 'ui_added', math.abs(count) })
-    end
+		TriggerClientEvent('ox_inventory:itemNotify', inv.id,
+			{ currentSlot, count < 0 and 'ui_removed' or 'ui_added', math.abs(count) })
+	end
 
-    inv.weight = newWeight
-    inv.items[slot] = currentSlot
-    inv.changed = true
+	inv.weight = newWeight
+	inv.items[slot] = currentSlot
+	inv.changed = true
 
-    return currentSlot
+	return currentSlot
 end
 
 local Items = require 'modules.items.server'
 
 CreateThread(function()
-    Inventory.accounts = server.accounts
-    TriggerEvent('ox_inventory:loadInventory', Inventory)
+	Inventory.accounts = server.accounts
+	TriggerEvent('ox_inventory:loadInventory', Inventory)
 end)
 
 function Inventory.GetAccountItemCounts(inv)
-    inv = Inventory(inv)
+	inv = Inventory(inv)
 
-    if not inv then return end
+	if not inv then return end
 
-    local accounts = table.clone(server.accounts)
+	local accounts = table.clone(server.accounts)
 
-    for _, v in pairs(inv.items) do
-        if accounts[v.name] then
-            accounts[v.name] += v.count
-        end
-    end
+	for _, v in pairs(inv.items) do
+		if accounts[v.name] then
+			accounts[v.name] += v.count
+		end
+	end
 
-    return accounts
+	return accounts
 end
 
 ---@param item table
 ---@param slot table
 function Inventory.SlotWeight(item, slot, ignoreCount)
-    local weight = ignoreCount and item.weight or item.weight * (slot.count or 1)
+	local weight = ignoreCount and item.weight or item.weight * (slot.count or 1)
 
-    if not slot.metadata then slot.metadata = {} end
+	if not slot.metadata then slot.metadata = {} end
 
-    if item.ammoname and slot.metadata.ammo then
-        local ammoWeight = Items(item.ammoname)?.weight
+	if item.ammoname and slot.metadata.ammo then
+		local ammoWeight = Items(item.ammoname)?.weight
 
-        if ammoWeight then
-            weight += (ammoWeight * slot.metadata.ammo)
-        end
-    end
+		if ammoWeight then
+			weight += (ammoWeight * slot.metadata.ammo)
+		end
+	end
 
-    if item.hash == `WEAPON_PETROLCAN` then
-        slot.metadata.weight = 15000 * (slot.metadata.ammo / 100)
-    end
+	if item.hash == `WEAPON_PETROLCAN` then
+		slot.metadata.weight = 15000 * (slot.metadata.ammo / 100)
+	end
 
-    if slot.metadata.components then
-        for i = #slot.metadata.components, 1, -1 do
-            local componentWeight = Items(slot.metadata.components[i])?.weight
+	if slot.metadata.components then
+		for i = #slot.metadata.components, 1, -1 do
+			local componentWeight = Items(slot.metadata.components[i])?.weight
 
-            if componentWeight then
-                weight += componentWeight
-            end
-        end
-    end
+			if componentWeight then
+				weight += componentWeight
+			end
+		end
+	end
 
-    if slot.metadata.weight then
-        weight += ignoreCount and slot.metadata.weight or (slot.metadata.weight * (slot.count or 1))
-    end
+	if slot.metadata.weight then
+		weight += ignoreCount and slot.metadata.weight or (slot.metadata.weight * (slot.count or 1))
+	end
 
-    return weight
+	return weight
 end
 
 ---@param items table
 function Inventory.CalculateWeight(items)
-    local weight = 0
-    for _, v in pairs(items) do
-        local item = Items(v.name)
-        if item then
-            weight = weight + Inventory.SlotWeight(item, v)
-        end
-    end
-    return weight
+	local weight = 0
+	for _, v in pairs(items) do
+		local item = Items(v.name)
+		if item then
+			weight = weight + Inventory.SlotWeight(item, v)
+		end
+	end
+	return weight
 end
 
 -- This should be handled by frameworks, but sometimes isn't or is exploitable in some way.
 local activeIdentifiers = {}
 
 local function hasActiveInventory(playerId, owner)
-    local activePlayer = activeIdentifiers[owner]
+	local activePlayer = activeIdentifiers[owner]
 
-    if activePlayer then
-        if activePlayer == playerId then
-            error('attempted to load active player\'s inventory a secondary time', 0)
-        end
+	if activePlayer then
+		if activePlayer == playerId then
+			error('attempted to load active player\'s inventory a secondary time', 0)
+		end
 
-        local inventory = Inventory(activePlayer)
+		local inventory = Inventory(activePlayer)
 
-        if inventory then
-            local endpoint = GetPlayerEndpoint(activePlayer)
+		if inventory then
+			local endpoint = GetPlayerEndpoint(activePlayer)
 
-            if endpoint then
-                DropPlayer(playerId, ("Character identifier '%s' is already active."):format(owner))
+			if endpoint then
+				DropPlayer(playerId, ("Character identifier '%s' is already active."):format(owner))
 
-                -- Supposedly still getting stuck? Print info and hope somebody reports back (lol)
-                print(('kicked player.%s (charid is already in use)'):format(playerId), json.encode({
-                    oldId = activePlayer,
-                    newId = playerId,
-                    charid = owner,
-                    endpoint = endpoint,
-                    playerName = GetPlayerName(activePlayer),
-                    fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
-                    license = GetPlayerIdentifierByType(activePlayer, 'license2') or
-                        GetPlayerIdentifierByType(activePlayer, 'license'),
-                }, {
-                    indent = true,
-                    sort_keys = true
-                }))
+				-- Supposedly still getting stuck? Print info and hope somebody reports back (lol)
+				print(('kicked player.%s (charid is already in use)'):format(playerId), json.encode({
+					oldId = activePlayer,
+					newId = playerId,
+					charid = owner,
+					endpoint = endpoint,
+					playerName = GetPlayerName(activePlayer),
+					fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
+					license = GetPlayerIdentifierByType(activePlayer, 'license2') or
+						GetPlayerIdentifierByType(activePlayer, 'license'),
+				}, {
+					indent = true,
+					sort_keys = true
+				}))
 
-                return true
-            end
+				return true
+			end
 
-            Inventory.CloseAll(inventory)
-            db.savePlayer(owner, json.encode(inventory:minimal()))
-            Inventory.Remove(inventory)
-            Wait(100)
-        end
-    end
+			Inventory.CloseAll(inventory)
+			db.savePlayer(owner, json.encode(inventory:minimal()))
+			Inventory.Remove(inventory)
+			Wait(100)
+		end
+	end
 
-    activeIdentifiers[owner] = playerId
+	activeIdentifiers[owner] = playerId
 end
 
 ---Manually clear an inventory state tied to the given identifier.
 ---Temporary workaround until somebody actually gives me info.
 RegisterCommand('clearActiveIdentifier', function(source, args)
-    ---Server console only.
-    if source ~= 0 then return end
+	---Server console only.
+	if source ~= 0 then return end
 
-    local activePlayer = activeIdentifiers[args[1]] or activeIdentifiers[tonumber(args[1])]
-    local inventory = activePlayer and Inventory(activePlayer)
+	local activePlayer = activeIdentifiers[args[1]] or activeIdentifiers[tonumber(args[1])]
+	local inventory = activePlayer and Inventory(activePlayer)
 
-    if not inventory then return end
+	if not inventory then return end
 
-    local endpoint = GetPlayerEndpoint(activePlayer)
+	local endpoint = GetPlayerEndpoint(activePlayer)
 
-    if endpoint then
-        DropPlayer(activePlayer, 'Kicked')
+	if endpoint then
+		DropPlayer(activePlayer, 'Kicked')
 
-        -- Supposedly still getting stuck? Print info and hope somebody reports back (lol)
-        print(('kicked player.%s (clearActiveIdentifier)'):format(activePlayer), json.encode({
-            oldId = activePlayer,
-            charid = inventory.owner,
-            endpoint = endpoint,
-            playerName = GetPlayerName(activePlayer),
-            fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
-            license = GetPlayerIdentifierByType(activePlayer, 'license2') or
-                GetPlayerIdentifierByType(activePlayer, 'license'),
-        }, {
-            indent = true,
-            sort_keys = true
-        }))
-    end
+		-- Supposedly still getting stuck? Print info and hope somebody reports back (lol)
+		print(('kicked player.%s (clearActiveIdentifier)'):format(activePlayer), json.encode({
+			oldId = activePlayer,
+			charid = inventory.owner,
+			endpoint = endpoint,
+			playerName = GetPlayerName(activePlayer),
+			fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
+			license = GetPlayerIdentifierByType(activePlayer, 'license2') or
+				GetPlayerIdentifierByType(activePlayer, 'license'),
+		}, {
+			indent = true,
+			sort_keys = true
+		}))
+	end
 
-    Inventory.CloseAll(inventory)
-    db.savePlayer(inventory.owner, json.encode(inventory:minimal()))
-    Inventory.Remove(inventory)
+	Inventory.CloseAll(inventory)
+	db.savePlayer(inventory.owner, json.encode(inventory:minimal()))
+	Inventory.Remove(inventory)
 end, true)
 
 ---@param id string|number
@@ -580,79 +580,79 @@ end, true)
 --- This should only be utilised internally!
 --- To create a stash, please use `exports.ox_inventory:RegisterStash` instead.
 function Inventory.Create(id, label, invType, slots, weight, maxWeight, owner, items, groups, dbId)
-    if invType == 'player' and hasActiveInventory(id, owner) then return end
+	if invType == 'player' and hasActiveInventory(id, owner) then return end
 
-    local self = {
-        id = id,
-        label = label or id,
-        type = invType,
-        slots = slots,
-        weight = weight,
-        maxWeight = maxWeight or shared.playerweight,
-        owner = owner,
-        items = type(items) == 'table' and items,
-        open = false,
-        set = Inventory.Set,
-        get = Inventory.Get,
-        minimal = minimal,
-        time = os.time(),
-        groups = groups,
-        openedBy = {},
-        dbId = dbId
-    }
+	local self = {
+		id = id,
+		label = label or id,
+		type = invType,
+		slots = slots,
+		weight = weight,
+		maxWeight = maxWeight or shared.playerweight,
+		owner = owner,
+		items = type(items) == 'table' and items,
+		open = false,
+		set = Inventory.Set,
+		get = Inventory.Get,
+		minimal = minimal,
+		time = os.time(),
+		groups = groups,
+		openedBy = {},
+		dbId = dbId
+	}
 
-    if invType == 'drop' or invType == 'temp' or invType == 'dumpster' then
-        self.datastore = true
-    else
-        self.changed = false
+	if invType == 'drop' or invType == 'temp' or invType == 'dumpster' then
+		self.datastore = true
+	else
+		self.changed = false
 
-        if invType ~= 'glovebox' and invType ~= 'trunk' then
-            self.dbId = id
+		if invType ~= 'glovebox' and invType ~= 'trunk' then
+			self.dbId = id
 
-            if invType ~= 'player' and owner and type(owner) ~= 'boolean' then
-                self.id = ('%s:%s'):format(self.id, owner)
-            end
-        end
-    end
+			if invType ~= 'player' and owner and type(owner) ~= 'boolean' then
+				self.id = ('%s:%s'):format(self.id, owner)
+			end
+		end
+	end
 
-    if not items then
-        self.items, self.weight = Inventory.Load(self.dbId, invType, owner)
-    elseif weight == 0 and next(items) then
-        self.weight = Inventory.CalculateWeight(items)
-    end
+	if not items then
+		self.items, self.weight = Inventory.Load(self.dbId, invType, owner)
+	elseif weight == 0 and next(items) then
+		self.weight = Inventory.CalculateWeight(items)
+	end
 
-    Inventories[self.id] = setmetatable(self, OxInventory)
-    return Inventories[self.id]
+	Inventories[self.id] = setmetatable(self, OxInventory)
+	return Inventories[self.id]
 end
 
 ---@param inv inventory
 function Inventory.Remove(inv)
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if not inv then return end
+	if not inv then return end
 
-    if inv.type == 'drop' then
-        TriggerClientEvent('ox_inventory:removeDrop', -1, inv.id)
-        Inventory.Drops[inv.id] = nil
-    elseif inv.player then
-        activeIdentifiers[inv.owner] = nil
-    end
+	if inv.type == 'drop' then
+		TriggerClientEvent('ox_inventory:removeDrop', -1, inv.id)
+		Inventory.Drops[inv.id] = nil
+	elseif inv.player then
+		activeIdentifiers[inv.owner] = nil
+	end
 
-    for playerId in pairs(inv.openedBy) do
-        if inv.id ~= playerId then
-            local target = Inventories[playerId]
+	for playerId in pairs(inv.openedBy) do
+		if inv.id ~= playerId then
+			local target = Inventories[playerId]
 
-            if target then
-                target:closeInventory()
-            end
-        end
-    end
+			if target then
+				target:closeInventory()
+			end
+		end
+	end
 
-    if not inv.datastore and inv.changed then
-        Inventory.Save(inv)
-    end
+	if not inv.datastore and inv.changed then
+		Inventory.Save(inv)
+	end
 
-    Inventories[inv.id] = nil
+	Inventories[inv.id] = nil
 end
 
 exports('RemoveInventory', Inventory.Remove)
@@ -661,71 +661,71 @@ exports('RemoveInventory', Inventory.Remove)
 ---@param oldPlate string
 ---@param newPlate string
 function Inventory.UpdateVehicle(oldPlate, newPlate)
-    oldPlate = oldPlate:upper()
-    newPlate = newPlate:upper()
+	oldPlate = oldPlate:upper()
+	newPlate = newPlate:upper()
 
-    if server.trimplate then
-        oldPlate = string.strtrim(oldPlate)
-        newPlate = string.strtrim(newPlate)
-    end
+	if server.trimplate then
+		oldPlate = string.strtrim(oldPlate)
+		newPlate = string.strtrim(newPlate)
+	end
 
-    local trunk = Inventory(('trunk%s'):format(oldPlate))
-    local glove = Inventory(('glove%s'):format(oldPlate))
+	local trunk = Inventory(('trunk%s'):format(oldPlate))
+	local glove = Inventory(('glove%s'):format(oldPlate))
 
-    if trunk then
-        Inventory.CloseAll(trunk)
+	if trunk then
+		Inventory.CloseAll(trunk)
 
-        Inventories[trunk.id] = nil
-        trunk.label = newPlate
-        trunk.dbId = type(trunk.id) == 'number' and trunk.dbId or newPlate
-        trunk.id = ('trunk%s'):format(newPlate)
-        Inventories[trunk.id] = trunk
-    end
+		Inventories[trunk.id] = nil
+		trunk.label = newPlate
+		trunk.dbId = type(trunk.id) == 'number' and trunk.dbId or newPlate
+		trunk.id = ('trunk%s'):format(newPlate)
+		Inventories[trunk.id] = trunk
+	end
 
-    if glove then
-        Inventory.CloseAll(glove)
+	if glove then
+		Inventory.CloseAll(glove)
 
-        Inventories[glove.id] = nil
-        glove.label = newPlate
-        glove.dbId = type(glove.id) == 'number' and glove.dbId or newPlate
-        glove.id = ('glove%s'):format(newPlate)
-        Inventories[glove.id] = glove
-    end
+		Inventories[glove.id] = nil
+		glove.label = newPlate
+		glove.dbId = type(glove.id) == 'number' and glove.dbId or newPlate
+		glove.id = ('glove%s'):format(newPlate)
+		Inventories[glove.id] = glove
+	end
 end
 
 exports('UpdateVehicle', Inventory.UpdateVehicle)
 
 function Inventory.Save(inv)
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if not inv or inv.datastore then return end
+	if not inv or inv.datastore then return end
 
-    local buffer, n = {}, 0
+	local buffer, n = {}, 0
 
-    for k, v in pairs(inv.items) do
-        if not Items.UpdateDurability(inv, v, Items(v.name), nil, os.time()) then
-            n += 1
-            buffer[n] = {
-                name = v.name,
-                count = v.count,
-                slot = k,
-                metadata = next(v.metadata) and v.metadata or nil
-            }
-        end
-    end
+	for k, v in pairs(inv.items) do
+		if not Items.UpdateDurability(inv, v, Items(v.name), nil, os.time()) then
+			n += 1
+			buffer[n] = {
+				name = v.name,
+				count = v.count,
+				slot = k,
+				metadata = next(v.metadata) and v.metadata or nil
+			}
+		end
+	end
 
-    local data = next(buffer) and json.encode(buffer) or nil
-    inv.changed = false
+	local data = next(buffer) and json.encode(buffer) or nil
+	inv.changed = false
 
-    if inv.player then
-        return shared.framework ~= 'esx' and db.savePlayer(inv.owner, data)
-    elseif inv.type == 'trunk' then
-        return db.saveTrunk(inv.dbId, data)
-    elseif inv.type == 'glovebox' then
-        return db.saveGlovebox(inv.dbId, data)
-    end
+	if inv.player then
+		return shared.framework ~= 'esx' and db.savePlayer(inv.owner, data)
+	elseif inv.type == 'trunk' then
+		return db.saveTrunk(inv.dbId, data)
+	elseif inv.type == 'glovebox' then
+		return db.saveGlovebox(inv.dbId, data)
+	end
 
-    return db.saveStash(inv.owner, inv.dbId, data)
+	return db.saveStash(inv.owner, inv.dbId, data)
 end
 
 ---@alias RandomLoot { [1]: string, [2]: number, [3]: number, [4]?: number }
@@ -735,51 +735,51 @@ end
 ---@param size number
 ---@return RandomLoot
 local function randomItem(loot, items, size)
-    local itemIndex = math.random(1, size)
-    local selectedItem = nil
+	local itemIndex = math.random(1, size)
+	local selectedItem = nil
 
-    for _ = 1, size do
-        selectedItem = loot[itemIndex]
-        local found = false
+	for _ = 1, size do
+		selectedItem = loot[itemIndex]
+		local found = false
 
-        for i = 1, #items do
-            if items[i][1] == selectedItem[1] then
-                found = true
-                break
-            end
-        end
+		for i = 1, #items do
+			if items[i][1] == selectedItem[1] then
+				found = true
+				break
+			end
+		end
 
-        if not found then break end
+		if not found then break end
 
-        itemIndex = ((itemIndex - 1) % size) + 1
-    end
+		itemIndex = ((itemIndex - 1) % size) + 1
+	end
 
-    return selectedItem
+	return selectedItem
 end
 
 ---@param loot RandomLoot[]
 ---@return RandomLoot[]
 local function randomLoot(loot)
-    ---@type RandomLoot[]
-    local items = {}
-    local size = #loot
-    local itemCount = math.random(0, 3)
+	---@type RandomLoot[]
+	local items = {}
+	local size = #loot
+	local itemCount = math.random(0, 3)
 
-    for _ = 1, itemCount do
-        if #items >= size then break end
+	for _ = 1, itemCount do
+		if #items >= size then break end
 
-        local item = randomItem(loot, items, size)
+		local item = randomItem(loot, items, size)
 
-        if item and math.random(1, 100) <= (item[4] or 80) then
-            local count = math.random(item[2], item[3])
+		if item and math.random(1, 100) <= (item[4] or 80) then
+			local count = math.random(item[2], item[3])
 
-            if count > 0 then
-                items[#items + 1] = { item[1], count }
-            end
-        end
-    end
+			if count > 0 then
+				items[#items + 1] = { item[1], count }
+			end
+		end
+	end
 
-    return items
+	return items
 end
 
 ---@param inv inventory
@@ -787,112 +787,112 @@ end
 ---@param items? table
 ---@return table returnData, number totalWeight
 local function generateItems(inv, invType, items)
-    if items == nil then
-        if invType == 'dumpster' then
-            items = randomLoot(server.dumpsterloot)
-        elseif invType == 'vehicle' then
-            items = randomLoot(server.vehicleloot)
-        end
-    end
+	if items == nil then
+		if invType == 'dumpster' then
+			items = randomLoot(server.dumpsterloot)
+		elseif invType == 'vehicle' then
+			items = randomLoot(server.vehicleloot)
+		end
+	end
 
-    if not items then
-        items = {}
-    end
+	if not items then
+		items = {}
+	end
 
-    local returnData, totalWeight = table.create(#items, 0), 0
-    for i = 1, #items do
-        local v = items[i]
-        local item = Items(v[1])
-        if not item then
-            warn('unable to generate', v[1], 'item does not exist')
-        else
-            local metadata, count = Items.Metadata(inv, item, v[3] or {}, v[2])
-            local weight = Inventory.SlotWeight(item, { count = count, metadata = metadata })
-            totalWeight = totalWeight + weight
-            returnData[i] = {
-                name = item.name,
-                label = item.label,
-                weight = weight,
-                slot = i,
-                count = count,
-                description =
-                    item.description,
-                metadata = metadata,
-                stack = item.stack,
-                close = item.close
-            }
-        end
-    end
+	local returnData, totalWeight = table.create(#items, 0), 0
+	for i = 1, #items do
+		local v = items[i]
+		local item = Items(v[1])
+		if not item then
+			warn('unable to generate', v[1], 'item does not exist')
+		else
+			local metadata, count = Items.Metadata(inv, item, v[3] or {}, v[2])
+			local weight = Inventory.SlotWeight(item, { count = count, metadata = metadata })
+			totalWeight = totalWeight + weight
+			returnData[i] = {
+				name = item.name,
+				label = item.label,
+				weight = weight,
+				slot = i,
+				count = count,
+				description =
+					item.description,
+				metadata = metadata,
+				stack = item.stack,
+				close = item.close
+			}
+		end
+	end
 
-    return returnData, totalWeight
+	return returnData, totalWeight
 end
 
 ---@param id string|number
 ---@param invType string
 ---@param owner string | number | boolean
 function Inventory.Load(id, invType, owner)
-    if not invType then return end
+	if not invType then return end
 
-    local result
+	local result
 
-    if invType == 'trunk' or invType == 'glovebox' then
-        result = id and (invType == 'trunk' and db.loadTrunk(id) or db.loadGlovebox(id))
+	if invType == 'trunk' or invType == 'glovebox' then
+		result = id and (invType == 'trunk' and db.loadTrunk(id) or db.loadGlovebox(id))
 
-        if not result then
-            if server.randomloot then
-                return generateItems(id, 'vehicle')
-            end
-        else
-            result = result[invType]
-        end
-    elseif invType == 'dumpster' then
-        if server.randomloot then
-            return generateItems(id, invType)
-        end
-    elseif id then
-        result = db.loadStash(owner or '', id)
-    end
+		if not result then
+			if server.randomloot then
+				return generateItems(id, 'vehicle')
+			end
+		else
+			result = result[invType]
+		end
+	elseif invType == 'dumpster' then
+		if server.randomloot then
+			return generateItems(id, invType)
+		end
+	elseif id then
+		result = db.loadStash(owner or '', id)
+	end
 
-    local returnData, weight = {}, 0
+	local returnData, weight = {}, 0
 
-    if result and type(result) == 'string' then
-        result = json.decode(result)
-    end
+	if result and type(result) == 'string' then
+		result = json.decode(result)
+	end
 
-    if result then
-        local ostime = os.time()
+	if result then
+		local ostime = os.time()
 
-        for _, v in pairs(result) do
-            local item = Items(v.name)
-            if item then
-                v.metadata = Items.CheckMetadata(v.metadata or {}, item, v.name, ostime)
-                local slotWeight = Inventory.SlotWeight(item, v)
-                weight += slotWeight
-                returnData[v.slot] = {
-                    name = item.name,
-                    label = item.label,
-                    weight = slotWeight,
-                    slot = v.slot,
-                    count =
-                        v.count,
-                    description = item.description,
-                    metadata = v.metadata,
-                    stack = item.stack,
-                    close = item.close
-                }
-            end
-        end
-    end
+		for _, v in pairs(result) do
+			local item = Items(v.name)
+			if item then
+				v.metadata = Items.CheckMetadata(v.metadata or {}, item, v.name, ostime)
+				local slotWeight = Inventory.SlotWeight(item, v)
+				weight += slotWeight
+				returnData[v.slot] = {
+					name = item.name,
+					label = item.label,
+					weight = slotWeight,
+					slot = v.slot,
+					count =
+						v.count,
+					description = item.description,
+					metadata = v.metadata,
+					stack = item.stack,
+					close = item.close
+				}
+			end
+		end
+	end
 
-    return returnData, weight
+	return returnData, weight
 end
 
 local function assertMetadata(metadata)
-    if metadata and type(metadata) ~= 'table' then
-        metadata = metadata and { type = metadata or nil }
-    end
+	if metadata and type(metadata) ~= 'table' then
+		metadata = metadata and { type = metadata or nil }
+	end
 
-    return metadata
+	return metadata
 end
 
 ---@param inv inventory
@@ -901,31 +901,31 @@ end
 ---@param returnsCount? boolean
 ---@return table | number | nil
 function Inventory.GetItem(inv, item, metadata, returnsCount)
-    if type(item) ~= 'table' then item = Items(item) end
+	if type(item) ~= 'table' then item = Items(item) end
 
-    if item then
-        item = returnsCount and item or table.clone(item)
-        inv = Inventory(inv) --[[@as OxInventory]]
-        local count = 0
+	if item then
+		item = returnsCount and item or table.clone(item)
+		inv = Inventory(inv) --[[@as OxInventory]]
+		local count = 0
 
-        if inv then
-            local ostime = os.time()
-            metadata = assertMetadata(metadata)
+		if inv then
+			local ostime = os.time()
+			metadata = assertMetadata(metadata)
 
-            for _, v in pairs(inv.items) do
-                if v.name == item.name and (not metadata or table.contains(v.metadata, metadata)) and not Items.UpdateDurability(inv, v, item, nil, ostime) then
-                    count += v.count
-                end
-            end
-        end
+			for _, v in pairs(inv.items) do
+				if v.name == item.name and (not metadata or table.contains(v.metadata, metadata)) and not Items.UpdateDurability(inv, v, item, nil, ostime) then
+					count += v.count
+				end
+			end
+		end
 
-        if returnsCount then
-            return count
-        else
-            item.count = count
-            return item
-        end
-    end
+		if returnsCount then
+			return count
+		else
+			item.count = count
+			return item
+		end
+	end
 end
 
 exports('GetItem', Inventory.GetItem)
@@ -935,26 +935,26 @@ exports('GetItem', Inventory.GetItem)
 ---@param slot1 number
 ---@param slot2 number
 function Inventory.SwapSlots(fromInventory, toInventory, slot1, slot2)
-    local fromSlot = fromInventory.items[slot1] and table.clone(fromInventory.items[slot1]) or nil
-    local toSlot = toInventory.items[slot2] and table.clone(toInventory.items[slot2]) or nil
+	local fromSlot = fromInventory.items[slot1] and table.clone(fromInventory.items[slot1]) or nil
+	local toSlot = toInventory.items[slot2] and table.clone(toInventory.items[slot2]) or nil
 
-    if fromSlot then fromSlot.slot = slot2 end
-    if toSlot then toSlot.slot = slot1 end
+	if fromSlot then fromSlot.slot = slot2 end
+	if toSlot then toSlot.slot = slot1 end
 
-    fromInventory.items[slot1], toInventory.items[slot2] = toSlot, fromSlot
-    fromInventory.changed, toInventory.changed = true, true
+	fromInventory.items[slot1], toInventory.items[slot2] = toSlot, fromSlot
+	fromInventory.changed, toInventory.changed = true, true
 
-    return fromSlot, toSlot
+	return fromSlot, toSlot
 end
 
 exports('SwapSlots', Inventory.SwapSlots)
 
 function Inventory.ContainerWeight(container, metaWeight, playerInventory)
-    playerInventory.weight -= container.weight
-    container.weight = Items(container.name).weight
-    container.weight += metaWeight
-    container.metadata.weight = metaWeight
-    playerInventory.weight += container.weight
+	playerInventory.weight -= container.weight
+	container.weight = Items(container.name).weight
+	container.weight += metaWeight
+	container.metadata.weight = metaWeight
+	playerInventory.weight += container.weight
 end
 
 ---@param inv inventory
@@ -963,45 +963,45 @@ end
 ---@param metadata? table
 ---@return boolean? success, string|SlotWithItem|nil response
 function Inventory.SetItem(inv, item, count, metadata)
-    if type(item) ~= 'table' then item = Items(item) end
+	if type(item) ~= 'table' then item = Items(item) end
 
-    if not item then return false, 'invalid_item' end
-    if type(count) ~= 'number' then return false, 'invalid_count' end
+	if not item then return false, 'invalid_item' end
+	if type(count) ~= 'number' then return false, 'invalid_count' end
 
-    count = math.floor(count + 0.5)
-    if count < 0 then return false, 'negative_count' end
+	count = math.floor(count + 0.5)
+	if count < 0 then return false, 'negative_count' end
 
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if not inv then return false, 'invalid_inventory' end
+	if not inv then return false, 'invalid_inventory' end
 
-    inv.changed = true
-    local itemCount = Inventory.GetItem(inv, item.name, metadata, true) --[[@as number]]
+	inv.changed = true
+	local itemCount = Inventory.GetItem(inv, item.name, metadata, true) --[[@as number]]
 
-    if count > itemCount then
-        count -= itemCount
-        return Inventory.AddItem(inv, item.name, count, metadata)
-    elseif count < itemCount then
-        itemCount -= count
-        return Inventory.RemoveItem(inv, item.name, itemCount, metadata)
-    end
+	if count > itemCount then
+		count -= itemCount
+		return Inventory.AddItem(inv, item.name, count, metadata)
+	elseif count < itemCount then
+		itemCount -= count
+		return Inventory.RemoveItem(inv, item.name, itemCount, metadata)
+	end
 end
 
 exports('SetItem', Inventory.SetItem)
 
 ---@param inv inventory
 function Inventory.GetCurrentWeapon(inv)
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if inv?.player then
-        local weapon = inv.items[inv.weapon]
+	if inv?.player then
+		local weapon = inv.items[inv.weapon]
 
-        if weapon and Items(weapon.name).weapon then
-            return weapon
-        end
+		if weapon and Items(weapon.name).weapon then
+			return weapon
+		end
 
-        inv.weapon = nil
-    end
+		inv.weapon = nil
+	end
 end
 
 exports('GetCurrentWeapon', Inventory.GetCurrentWeapon)
@@ -1010,14 +1010,14 @@ exports('GetCurrentWeapon', Inventory.GetCurrentWeapon)
 ---@param slotId number
 ---@return table? item
 function Inventory.GetSlot(inv, slotId)
-    if not inv or type(slotId) ~= 'number' then return end
+	if not inv or type(slotId) ~= 'number' then return end
 
-    inv = Inventory(inv) --[[@as OxInventory]]
-    local slot = inv and inv.items?[slotId]
+	inv = Inventory(inv) --[[@as OxInventory]]
+	local slot = inv and inv.items?[slotId]
 
-    if slot and not Items.UpdateDurability(inv, slot, Items(slot.name), nil, os.time()) then
-        return slot
-    end
+	if slot and not Items.UpdateDurability(inv, slot, Items(slot.name), nil, os.time()) then
+		return slot
+	end
 end
 
 exports('GetSlot', Inventory.GetSlot)
@@ -1026,18 +1026,18 @@ exports('GetSlot', Inventory.GetSlot)
 ---@param slotId number
 ---@param durability number
 function Inventory.SetDurability(inv, slotId, durability)
-    if not inv or type(slotId) ~= 'number' or type(durability) ~= 'number' then return end
+	if not inv or type(slotId) ~= 'number' or type(durability) ~= 'number' then return end
 
-    inv = Inventory(inv) --[[@as OxInventory]]
-    local slot = inv and inv.items?[slotId]
+	inv = Inventory(inv) --[[@as OxInventory]]
+	local slot = inv and inv.items?[slotId]
 
-    if not slot then return end
+	if not slot then return end
 
-    Items.UpdateDurability(inv, slot, Items(slot.name), durability)
+	Items.UpdateDurability(inv, slot, Items(slot.name), durability)
 
-    if inv.player and server.syncInventory then
-        server.syncInventory(inv)
-    end
+	if inv.player and server.syncInventory then
+		server.syncInventory(inv)
+	end
 end
 
 exports('SetDurability', Inventory.SetDurability)
@@ -1048,53 +1048,53 @@ local Utils = require 'modules.utils.server'
 ---@param slotId number
 ---@param metadata { [string]: any }
 function Inventory.SetMetadata(inv, slotId, metadata)
-    if not inv or type(slotId) ~= 'number' then return end
+	if not inv or type(slotId) ~= 'number' then return end
 
-    inv = Inventory(inv) --[[@as OxInventory]]
-    local slot = inv and inv.items?[slotId]
+	inv = Inventory(inv) --[[@as OxInventory]]
+	local slot = inv and inv.items?[slotId]
 
-    if not slot then return end
+	if not slot then return end
 
-    local item = Items(slot.name)
-    local imageurl = slot.metadata.imageurl
-    slot.metadata = type(metadata) == 'table' and metadata or { type = metadata or nil }
-    inv.changed = true
+	local item = Items(slot.name)
+	local imageurl = slot.metadata.imageurl
+	slot.metadata = type(metadata) == 'table' and metadata or { type = metadata or nil }
+	inv.changed = true
 
-    if metadata.weight then
-        inv.weight -= slot.weight
-        slot.weight = Inventory.SlotWeight(item, slot)
-        inv.weight += slot.weight
-    end
+	if metadata.weight then
+		inv.weight -= slot.weight
+		slot.weight = Inventory.SlotWeight(item, slot)
+		inv.weight += slot.weight
+	end
 
-    if metadata.durability ~= slot.metadata.durability then
-        Items.UpdateDurability(inv, slot, item, metadata.durability)
-    else
-        inv:syncSlotsWithClients({
-            {
-                item = slot,
-                inventory = inv.id
-            }
-        }, true)
-    end
+	if metadata.durability ~= slot.metadata.durability then
+		Items.UpdateDurability(inv, slot, item, metadata.durability)
+	else
+		inv:syncSlotsWithClients({
+			{
+				item = slot,
+				inventory = inv.id
+			}
+		}, true)
+	end
 
-    if inv.player and server.syncInventory then
-        server.syncInventory(inv)
-    end
+	if inv.player and server.syncInventory then
+		server.syncInventory(inv)
+	end
 
-    if metadata.imageurl ~= imageurl and Utils.IsValidImageUrl then
-        if Utils.IsValidImageUrl(metadata.imageurl) then
-            Utils.DiscordEmbed('Valid image URL',
-                ('Updated item "%s" (%s) with valid url in "%s".\n%s\nid: %s\nowner: %s'):format(
-                    metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id, inv.owner,
-                    metadata.imageurl), metadata.imageurl, 65280)
-        else
-            Utils.DiscordEmbed('Invalid image URL',
-                ('Updated item "%s" (%s) with invalid url in "%s".\n%s\nid: %s\nowner: %s'):format(
-                    metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id, inv.owner,
-                    metadata.imageurl), metadata.imageurl, 16711680)
-            metadata.imageurl = nil
-        end
-    end
+	if metadata.imageurl ~= imageurl and Utils.IsValidImageUrl then
+		if Utils.IsValidImageUrl(metadata.imageurl) then
+			Utils.DiscordEmbed('Valid image URL',
+				('Updated item "%s" (%s) with valid url in "%s".\n%s\nid: %s\nowner: %s'):format(
+					metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id, inv.owner,
+					metadata.imageurl), metadata.imageurl, 65280)
+		else
+			Utils.DiscordEmbed('Invalid image URL',
+				('Updated item "%s" (%s) with invalid url in "%s".\n%s\nid: %s\nowner: %s'):format(
+					metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id, inv.owner,
+					metadata.imageurl), metadata.imageurl, 16711680)
+			metadata.imageurl = nil
+		end
+	end
 end
 
 exports('SetMetadata', Inventory.SetMetadata)
@@ -1102,23 +1102,23 @@ exports('SetMetadata', Inventory.SetMetadata)
 ---@param inv inventory
 ---@param slots number
 function Inventory.SetSlotCount(inv, slots)
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if not inv then return end
-    if type(slots) ~= 'number' then return end
+	if not inv then return end
+	if type(slots) ~= 'number' then return end
 
-    inv.changed = true
-    inv.slots = slots
+	inv.changed = true
+	inv.slots = slots
 
-    if inv.player then
-        TriggerClientEvent('ox_inventory:refreshSlotCount', inv.id, { inventoryId = inv.id, slots = inv.slots })
-    end
+	if inv.player then
+		TriggerClientEvent('ox_inventory:refreshSlotCount', inv.id, { inventoryId = inv.id, slots = inv.slots })
+	end
 
-    for playerId in pairs(inv.openedBy) do
-        if playerId ~= inv.id then
-            TriggerClientEvent('ox_inventory:refreshSlotCount', playerId, { inventoryId = inv.id, slots = inv.slots })
-        end
-    end
+	for playerId in pairs(inv.openedBy) do
+		if playerId ~= inv.id then
+			TriggerClientEvent('ox_inventory:refreshSlotCount', playerId, { inventoryId = inv.id, slots = inv.slots })
+		end
+	end
 end
 
 exports('SetSlotCount', Inventory.SetSlotCount)
@@ -1126,23 +1126,23 @@ exports('SetSlotCount', Inventory.SetSlotCount)
 ---@param inv inventory
 ---@param maxWeight number
 function Inventory.SetMaxWeight(inv, maxWeight)
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if not inv then return end
-    if type(maxWeight) ~= 'number' then return end
+	if not inv then return end
+	if type(maxWeight) ~= 'number' then return end
 
-    inv.maxWeight = maxWeight
+	inv.maxWeight = maxWeight
 
-    if inv.player then
-        TriggerClientEvent('ox_inventory:refreshMaxWeight', inv.id, { inventoryId = inv.id, maxWeight = inv.maxWeight })
-    end
+	if inv.player then
+		TriggerClientEvent('ox_inventory:refreshMaxWeight', inv.id, { inventoryId = inv.id, maxWeight = inv.maxWeight })
+	end
 
-    for playerId in pairs(inv.openedBy) do
-        if playerId ~= inv.id then
-            TriggerClientEvent('ox_inventory:refreshMaxWeight', playerId,
-                { inventoryId = inv.id, maxWeight = inv.maxWeight })
-        end
-    end
+	for playerId in pairs(inv.openedBy) do
+		if playerId ~= inv.id then
+			TriggerClientEvent('ox_inventory:refreshMaxWeight', playerId,
+				{ inventoryId = inv.id, maxWeight = inv.maxWeight })
+		end
+	end
 end
 
 exports('SetMaxWeight', Inventory.SetMaxWeight)
@@ -1155,149 +1155,149 @@ exports('SetMaxWeight', Inventory.SetMaxWeight)
 ---@param cb? fun(success?: boolean, response: string|SlotWithItem|nil)
 ---@return boolean? success, string|SlotWithItem|nil response
 function Inventory.AddItem(inv, item, count, metadata, slot, cb)
-    if type(item) ~= 'table' then item = Items(item) end
+	if type(item) ~= 'table' then item = Items(item) end
 
-    if not item then return false, 'invalid_item' end
-    if type(count) ~= 'number' then return false, 'invalid_count' end
+	if not item then return false, 'invalid_item' end
+	if type(count) ~= 'number' then return false, 'invalid_count' end
 
-    count = math.floor(count + 0.5)
-    if count <= 0 then return false, 'negative_count' end
+	count = math.floor(count + 0.5)
+	if count <= 0 then return false, 'negative_count' end
 
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if not inv?.slots then return false, 'invalid_inventory' end
+	if not inv?.slots then return false, 'invalid_inventory' end
 
-    local toSlot, slotMetadata, slotCount
-    local success, response = false
+	local toSlot, slotMetadata, slotCount
+	local success, response = false
 
-    metadata = assertMetadata(metadata)
+	metadata = assertMetadata(metadata)
 
-    if slot then
-        local slotData = inv.items[slot]
-        slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
+	if slot then
+		local slotData = inv.items[slot]
+		slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
 
-        if not slotData or item.stack == true then
-            toSlot = slot
-        elseif slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
-            if type(item.stack) == "number" then
-                local freeSpace = item.stack - slotData.count
-                if freeSpace > 0 then
-                    slotCount = math.min(count, freeSpace)
-                    toSlot = slot
-                    count = count - slotCount
-                end
-            end
-        end
-    end
+		if not slotData or item.stack == true then
+			toSlot = slot
+		elseif slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
+			if type(item.stack) == "number" then
+				local freeSpace = item.stack - slotData.count
+				if freeSpace > 0 then
+					slotCount = math.min(count, freeSpace)
+					toSlot = slot
+					count = count - slotCount
+				end
+			end
+		end
+	end
 
-    if not toSlot then
-        local items = inv.items
-        slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
+	if not toSlot then
+		local items = inv.items
+		slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
 
-        for i = 1, inv.slots do
-            local slotData = items[i]
+		for i = 1, inv.slots do
+			local slotData = items[i]
 
-            if type(item.stack) == 'number' and slotData ~= nil and slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
-                local freeSpace = item.stack - slotData.count
-                if freeSpace > 0 then
-                    if count <= freeSpace then
-                        toSlot = i
-                        slotCount = count
-                        count = 0
-                        break
-                    else
-                        if not toSlot or type(toSlot) ~= 'table' then toSlot = {} end
-                        toSlot[#toSlot + 1] = { slot = i, count = freeSpace, metadata = slotMetadata }
-                        count -= freeSpace
-                    end
-                end
-            elseif item.stack == true and slotData ~= nil and slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
-                toSlot = i
-                break
-            elseif not item.stack and not slotData then
-                if not toSlot then toSlot = {} end
-                toSlot[#toSlot + 1] = { slot = i, count = slotCount, metadata = slotMetadata }
-                if count == slotCount then
-                    break
-                end
-                count -= 1
-                slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
-            elseif not slotData then
-                if type(item.stack) == 'number' and count > 0 then
-                    if not toSlot or type(toSlot) ~= 'table' then toSlot = {} end
-                    local addCount = math.min(count, item.stack)
-                    toSlot[#toSlot + 1] = { slot = i, count = addCount, metadata = slotMetadata }
-                    count -= addCount
-                    if count <= 0 then break end
-                elseif not toSlot then
-                    toSlot = i
-                end
-            end
-        end
-    end
+			if type(item.stack) == 'number' and slotData ~= nil and slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
+				local freeSpace = item.stack - slotData.count
+				if freeSpace > 0 then
+					if count <= freeSpace then
+						toSlot = i
+						slotCount = count
+						count = 0
+						break
+					else
+						if not toSlot or type(toSlot) ~= 'table' then toSlot = {} end
+						toSlot[#toSlot + 1] = { slot = i, count = freeSpace, metadata = slotMetadata }
+						count -= freeSpace
+					end
+				end
+			elseif item.stack == true and slotData ~= nil and slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
+				toSlot = i
+				break
+			elseif not item.stack and not slotData then
+				if not toSlot then toSlot = {} end
+				toSlot[#toSlot + 1] = { slot = i, count = slotCount, metadata = slotMetadata }
+				if count == slotCount then
+					break
+				end
+				count -= 1
+				slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
+			elseif not slotData then
+				if type(item.stack) == 'number' and count > 0 then
+					if not toSlot or type(toSlot) ~= 'table' then toSlot = {} end
+					local addCount = math.min(count, item.stack)
+					toSlot[#toSlot + 1] = { slot = i, count = addCount, metadata = slotMetadata }
+					count -= addCount
+					if count <= 0 then break end
+				elseif not toSlot then
+					toSlot = i
+				end
+			end
+		end
+	end
 
-    if not toSlot then return false, 'inventory_full' end
+	if not toSlot then return false, 'inventory_full' end
 
-    inv.changed = true
+	inv.changed = true
 
-    local invokingResource = server.loglevel > 1 and GetInvokingResource()
-    local toSlotType = type(toSlot)
+	local invokingResource = server.loglevel > 1 and GetInvokingResource()
+	local toSlotType = type(toSlot)
 
-    if toSlotType == 'number' then
-        Inventory.SetSlot(inv, item, slotCount, slotMetadata, toSlot)
+	if toSlotType == 'number' then
+		Inventory.SetSlot(inv, item, slotCount, slotMetadata, toSlot)
 
-        if inv.player and server.syncInventory then
-            server.syncInventory(inv)
-        end
+		if inv.player and server.syncInventory then
+			server.syncInventory(inv)
+		end
 
-        inv:syncSlotsWithClients({
-            {
-                item = inv.items[toSlot],
-                inventory = inv.id
-            }
-        }, true)
+		inv:syncSlotsWithClients({
+			{
+				item = inv.items[toSlot],
+				inventory = inv.id
+			}
+		}, true)
 
-        if invokingResource then
-            lib.logger(inv.owner, 'addItem',
-                ('"%s" added %sx %s to "%s"'):format(invokingResource, count, item.name, inv.label))
-        end
+		if invokingResource then
+			lib.logger(inv.owner, 'addItem',
+				('"%s" added %sx %s to "%s"'):format(invokingResource, count, item.name, inv.label))
+		end
 
-        success = true
-        response = inv.items[toSlot]
-    elseif toSlotType == 'table' then
-        local added = 0
+		success = true
+		response = inv.items[toSlot]
+	elseif toSlotType == 'table' then
+		local added = 0
 
-        for i = 1, #toSlot do
-            local data = toSlot[i]
-            added += data.count
-            Inventory.SetSlot(inv, item, data.count, data.metadata, data.slot)
-            toSlot[i] = { item = inv.items[data.slot], inventory = inv.id }
-        end
+		for i = 1, #toSlot do
+			local data = toSlot[i]
+			added += data.count
+			Inventory.SetSlot(inv, item, data.count, data.metadata, data.slot)
+			toSlot[i] = { item = inv.items[data.slot], inventory = inv.id }
+		end
 
-        if inv.player and server.syncInventory then
-            server.syncInventory(inv)
-        end
+		if inv.player and server.syncInventory then
+			server.syncInventory(inv)
+		end
 
-        inv:syncSlotsWithClients(toSlot, true)
+		inv:syncSlotsWithClients(toSlot, true)
 
-        if invokingResource then
-            lib.logger(inv.owner, 'addItem',
-                ('"%s" added %sx %s to "%s"'):format(invokingResource, added, item.name, inv.label))
-        end
+		if invokingResource then
+			lib.logger(inv.owner, 'addItem',
+				('"%s" added %sx %s to "%s"'):format(invokingResource, added, item.name, inv.label))
+		end
 
-        for i = 1, #toSlot do
-            toSlot[i] = toSlot[i].item
-        end
+		for i = 1, #toSlot do
+			toSlot[i] = toSlot[i].item
+		end
 
-        success = true
-        response = toSlot
-    end
+		success = true
+		response = toSlot
+	end
 
-    if cb then
-        return cb(success, response)
-    end
+	if cb then
+		return cb(success, response)
+	end
 
-    return success, response
+	return success, response
 end
 
 exports('AddItem', Inventory.AddItem)
@@ -1307,49 +1307,49 @@ exports('AddItem', Inventory.AddItem)
 ---@param items table | string
 ---@param metadata? table | string
 function Inventory.Search(inv, search, items, metadata)
-    if items then
-        inv = Inventory(inv) --[[@as OxInventory]]
+	if items then
+		inv = Inventory(inv) --[[@as OxInventory]]
 
-        if inv then
-            inv = inv.items
+		if inv then
+			inv = inv.items
 
-            if search == 'slots' then search = 1 elseif search == 'count' then search = 2 end
-            if type(items) == 'string' then items = { items } end
+			if search == 'slots' then search = 1 elseif search == 'count' then search = 2 end
+			if type(items) == 'string' then items = { items } end
 
-            metadata = assertMetadata(metadata)
-            local itemCount = #items
-            local returnData = {}
+			metadata = assertMetadata(metadata)
+			local itemCount = #items
+			local returnData = {}
 
-            for i = 1, itemCount do
-                local item = string.lower(items[i])
-                if item:sub(0, 7) == 'weapon_' then item = string.upper(item) end
+			for i = 1, itemCount do
+				local item = string.lower(items[i])
+				if item:sub(0, 7) == 'weapon_' then item = string.upper(item) end
 
-                if search == 1 then
-                    returnData[item] = {}
-                elseif search == 2 then
-                    returnData[item] = 0
-                end
+				if search == 1 then
+					returnData[item] = {}
+				elseif search == 2 then
+					returnData[item] = 0
+				end
 
-                for _, v in pairs(inv) do
-                    if v.name == item then
-                        if not v.metadata then v.metadata = {} end
+				for _, v in pairs(inv) do
+					if v.name == item then
+						if not v.metadata then v.metadata = {} end
 
-                        if not metadata or table.contains(v.metadata, metadata) then
-                            if search == 1 then
-                                returnData[item][#returnData[item] + 1] = inv[v.slot]
-                            elseif search == 2 then
-                                returnData[item] += v.count
-                            end
-                        end
-                    end
-                end
-            end
+						if not metadata or table.contains(v.metadata, metadata) then
+							if search == 1 then
+								returnData[item][#returnData[item] + 1] = inv[v.slot]
+							elseif search == 2 then
+								returnData[item] += v.count
+							end
+						end
+					end
+				end
+			end
 
-            if next(returnData) then return itemCount == 1 and returnData[items[1]] or returnData end
-        end
-    end
+			if next(returnData) then return itemCount == 1 and returnData[items[1]] or returnData end
+		end
+	end
 
-    return false
+	return false
 end
 
 exports('Search', Inventory.Search)
@@ -1359,31 +1359,31 @@ exports('Search', Inventory.Search)
 ---@param metadata? table
 ---@param strict? boolean
 function Inventory.GetItemSlots(inv, item, metadata, strict)
-    if type(item) ~= 'table' then item = Items(item) end
-    if not item then return end
+	if type(item) ~= 'table' then item = Items(item) end
+	if not item then return end
 
-    inv = Inventory(inv) --[[@as OxInventory]]
-    if not inv?.slots then return end
+	inv = Inventory(inv) --[[@as OxInventory]]
+	if not inv?.slots then return end
 
-    local totalCount, slots, emptySlots = 0, {}, inv.slots
+	local totalCount, slots, emptySlots = 0, {}, inv.slots
 
-    if strict == nil then strict = true end
-    local tablematch = strict and table.matches or table.contains
+	if strict == nil then strict = true end
+	local tablematch = strict and table.matches or table.contains
 
-    for k, v in pairs(inv.items) do
-        emptySlots -= 1
-        if v.name == item.name then
-            if metadata and v.metadata == nil then
-                v.metadata = {}
-            end
-            if not metadata or tablematch(v.metadata, metadata) then
-                totalCount = totalCount + v.count
-                slots[k] = v.count
-            end
-        end
-    end
+	for k, v in pairs(inv.items) do
+		emptySlots -= 1
+		if v.name == item.name then
+			if metadata and v.metadata == nil then
+				v.metadata = {}
+			end
+			if not metadata or tablematch(v.metadata, metadata) then
+				totalCount = totalCount + v.count
+				slots[k] = v.count
+			end
+		end
+	end
 
-    return slots, totalCount, emptySlots
+	return slots, totalCount, emptySlots
 end
 
 exports('GetItemSlots', Inventory.GetItemSlots)
@@ -1397,92 +1397,92 @@ exports('GetItemSlots', Inventory.GetItemSlots)
 ---@param strict? boolean
 ---@return boolean? success, string? response
 function Inventory.RemoveItem(inv, item, count, metadata, slot, ignoreTotal, strict)
-    if type(item) ~= 'table' then item = Items(item) end
+	if type(item) ~= 'table' then item = Items(item) end
 
-    if not item then return false, 'invalid_item' end
-    if type(count) ~= 'number' then return false, 'invalid_count' end
+	if not item then return false, 'invalid_item' end
+	if type(count) ~= 'number' then return false, 'invalid_count' end
 
-    count = math.floor(count + 0.5)
-    if count <= 0 then return false, 'negative_count' end
+	count = math.floor(count + 0.5)
+	if count <= 0 then return false, 'negative_count' end
 
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if not inv?.slots then return false, 'invalid_inventory' end
+	if not inv?.slots then return false, 'invalid_inventory' end
 
-    metadata = assertMetadata(metadata)
-    if strict == nil then strict = true end
-    local itemSlots, totalCount = Inventory.GetItemSlots(inv, item, metadata, strict)
+	metadata = assertMetadata(metadata)
+	if strict == nil then strict = true end
+	local itemSlots, totalCount = Inventory.GetItemSlots(inv, item, metadata, strict)
 
-    if not itemSlots then return false end
+	if not itemSlots then return false end
 
-    if totalCount and count > totalCount then
-        if not ignoreTotal then return false, 'not_enough_items' end
+	if totalCount and count > totalCount then
+		if not ignoreTotal then return false, 'not_enough_items' end
 
-        count = totalCount
-    end
+		count = totalCount
+	end
 
-    local removed, total, slots = 0, count, {}
+	local removed, total, slots = 0, count, {}
 
-    if slot and itemSlots[slot] then
-        removed = count
-        Inventory.SetSlot(inv, item, -count, inv.items[slot].metadata, slot)
-        slots[#slots + 1] = inv.items[slot] or slot
-    elseif itemSlots and totalCount > 0 then
-        for k, v in pairs(itemSlots) do
-            if removed < total then
-                if v == count then
-                    TriggerClientEvent('ox_inventory:itemNotify', inv.id, { inv.items[k], 'ui_removed', v })
+	if slot and itemSlots[slot] then
+		removed = count
+		Inventory.SetSlot(inv, item, -count, inv.items[slot].metadata, slot)
+		slots[#slots + 1] = inv.items[slot] or slot
+	elseif itemSlots and totalCount > 0 then
+		for k, v in pairs(itemSlots) do
+			if removed < total then
+				if v == count then
+					TriggerClientEvent('ox_inventory:itemNotify', inv.id, { inv.items[k], 'ui_removed', v })
 
-                    removed = total
-                    inv.weight -= inv.items[k].weight
-                    inv.items[k] = nil
-                    slots[#slots + 1] = inv.items[k] or k
-                elseif v > count then
-                    Inventory.SetSlot(inv, item, -count, inv.items[k].metadata, k)
-                    slots[#slots + 1] = inv.items[k] or k
-                    removed = total
-                    count = v - count
-                else
-                    TriggerClientEvent('ox_inventory:itemNotify', inv.id, { inv.items[k], 'ui_removed', v })
+					removed = total
+					inv.weight -= inv.items[k].weight
+					inv.items[k] = nil
+					slots[#slots + 1] = inv.items[k] or k
+				elseif v > count then
+					Inventory.SetSlot(inv, item, -count, inv.items[k].metadata, k)
+					slots[#slots + 1] = inv.items[k] or k
+					removed = total
+					count = v - count
+				else
+					TriggerClientEvent('ox_inventory:itemNotify', inv.id, { inv.items[k], 'ui_removed', v })
 
-                    removed = removed + v
-                    count = count - v
-                    inv.weight -= inv.items[k].weight
-                    inv.items[k] = nil
-                    slots[#slots + 1] = k
-                end
-            else
-                break
-            end
-        end
-    end
+					removed = removed + v
+					count = count - v
+					inv.weight -= inv.items[k].weight
+					inv.items[k] = nil
+					slots[#slots + 1] = k
+				end
+			else
+				break
+			end
+		end
+	end
 
-    if removed > 0 then
-        inv.changed = true
+	if removed > 0 then
+		inv.changed = true
 
-        if inv.player and server.syncInventory then
-            server.syncInventory(inv)
-        end
+		if inv.player and server.syncInventory then
+			server.syncInventory(inv)
+		end
 
-        local array = table.create(#slots, 0)
+		local array = table.create(#slots, 0)
 
-        for k, v in pairs(slots) do
-            array[k] = { item = type(v) == 'number' and { slot = v } or v, inventory = inv.id }
-        end
+		for k, v in pairs(slots) do
+			array[k] = { item = type(v) == 'number' and { slot = v } or v, inventory = inv.id }
+		end
 
-        inv:syncSlotsWithClients(array, true)
+		inv:syncSlotsWithClients(array, true)
 
-        local invokingResource = server.loglevel > 1 and GetInvokingResource()
+		local invokingResource = server.loglevel > 1 and GetInvokingResource()
 
-        if invokingResource then
-            lib.logger(inv.owner, 'removeItem',
-                ('"%s" removed %sx %s from "%s"'):format(invokingResource, removed, item.name, inv.label))
-        end
+		if invokingResource then
+			lib.logger(inv.owner, 'removeItem',
+				('"%s" removed %sx %s from "%s"'):format(invokingResource, removed, item.name, inv.label))
+		end
 
-        return true
-    end
+		return true
+	end
 
-    return false, 'not_enough_items'
+	return false, 'not_enough_items'
 end
 
 exports('RemoveItem', Inventory.RemoveItem)
@@ -1492,34 +1492,34 @@ exports('RemoveItem', Inventory.RemoveItem)
 ---@param count number
 ---@param metadata? table | string
 function Inventory.CanCarryItem(inv, item, count, metadata)
-    if type(item) ~= 'table' then item = Items(item) end
+	if type(item) ~= 'table' then item = Items(item) end
 
-    if item then
-        inv = Inventory(inv) --[[@as OxInventory]]
+	if item then
+		inv = Inventory(inv) --[[@as OxInventory]]
 
-        if inv then
-            local itemSlots, _, emptySlots = Inventory.GetItemSlots(inv, item,
-                type(metadata) == 'table' and metadata or { type = metadata or nil })
+		if inv then
+			local itemSlots, _, emptySlots = Inventory.GetItemSlots(inv, item,
+				type(metadata) == 'table' and metadata or { type = metadata or nil })
 
-            if not itemSlots then return end
+			if not itemSlots then return end
 
-            local weight = metadata and metadata.weight or item.weight
+			local weight = metadata and metadata.weight or item.weight
 
-            if next(itemSlots) or emptySlots > 0 then
-                if not count then count = 1 end
-                if not item.stack and emptySlots < count then return false end
-                if weight == 0 then return true end
+			if next(itemSlots) or emptySlots > 0 then
+				if not count then count = 1 end
+				if not item.stack and emptySlots < count then return false end
+				if weight == 0 then return true end
 
-                local newWeight = inv.weight + (weight * count)
+				local newWeight = inv.weight + (weight * count)
 
-                if newWeight > inv.maxWeight then
-                    return false
-                end
+				if newWeight > inv.maxWeight then
+					return false
+				end
 
-                return true
-            end
-        end
-    end
+				return true
+			end
+		end
+	end
 end
 
 exports('CanCarryItem', Inventory.CanCarryItem)
@@ -1527,13 +1527,13 @@ exports('CanCarryItem', Inventory.CanCarryItem)
 ---@param inv inventory
 ---@param item table | string
 function Inventory.CanCarryAmount(inv, item)
-    if type(item) ~= 'table' then item = Items(item) end
-    inv = Inventory(inv) --[[@as OxInventory]]
+	if type(item) ~= 'table' then item = Items(item) end
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if inv and item then
-        local availableWeight = inv.maxWeight - inv.weight
-        return math.floor(availableWeight / item.weight)
-    end
+	if inv and item then
+		local availableWeight = inv.maxWeight - inv.weight
+		return math.floor(availableWeight / item.weight)
+	end
 end
 
 exports('CanCarryAmount', Inventory.CanCarryAmount)
@@ -1541,13 +1541,13 @@ exports('CanCarryAmount', Inventory.CanCarryAmount)
 ---@param inv inventory
 ---@param weight number
 function Inventory.CanCarryWeight(inv, weight)
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if not inv then return end
+	if not inv then return end
 
-    local availableWeight = inv.maxWeight - inv.weight
-    local canHold = availableWeight >= weight
-    return canHold, availableWeight
+	local availableWeight = inv.maxWeight - inv.weight
+	local canHold = availableWeight >= weight
+	return canHold, availableWeight
 end
 
 exports('CanCarryWeight', Inventory.CanCarryWeight)
@@ -1558,18 +1558,18 @@ exports('CanCarryWeight', Inventory.CanCarryWeight)
 ---@param testItem string
 ---@param testItemCount number
 function Inventory.CanSwapItem(inv, firstItem, firstItemCount, testItem, testItemCount)
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if not inv then return end
+	if not inv then return end
 
-    local firstItemData = Inventory.GetItem(inv, firstItem)
-    local testItemData = Inventory.GetItem(inv, testItem)
+	local firstItemData = Inventory.GetItem(inv, firstItem)
+	local testItemData = Inventory.GetItem(inv, testItem)
 
-    if firstItemData and testItemData and firstItemData.count >= firstItemCount then
-        local weightWithoutFirst = inv.weight - (firstItemData.weight * firstItemCount)
-        local weightWithTest = weightWithoutFirst + (testItemData.weight * testItemCount)
-        return weightWithTest <= inv.maxWeight
-    end
+	if firstItemData and testItemData and firstItemData.count >= firstItemCount then
+		local weightWithoutFirst = inv.weight - (firstItemData.weight * firstItemCount)
+		local weightWithTest = weightWithoutFirst + (testItemData.weight * testItemCount)
+		return weightWithTest <= inv.maxWeight
+	end
 end
 
 exports('CanSwapItem', Inventory.CanSwapItem)
@@ -1580,7 +1580,7 @@ exports('CanSwapItem', Inventory.CanSwapItem)
 ---@param metadata { [string]: any }
 ---@param slot number
 RegisterServerEvent('ox_inventory:removeItem', function(name, count, metadata, slot)
-    Inventory.RemoveItem(source, name, count, metadata, slot)
+	Inventory.RemoveItem(source, name, count, metadata, slot)
 end)
 
 Inventory.Drops = {}
@@ -1588,60 +1588,60 @@ Inventory.Drops = {}
 ---@param prefix string?
 ---@return string
 local function generateInvId(prefix)
-    while true do
-        local invId = ('%s-%s'):format(prefix or 'drop', math.random(100000, 999999))
+	while true do
+		local invId = ('%s-%s'):format(prefix or 'drop', math.random(100000, 999999))
 
-        if not Inventories[invId] then return invId end
+		if not Inventories[invId] then return invId end
 
-        Wait(0)
-    end
+		Wait(0)
+	end
 end
 
 local function CustomDrop(prefix, items, coords, slots, maxWeight, instance, model)
-    local dropId = generateInvId()
-    local inventory = Inventory.Create(dropId, ('%s %s'):format(prefix, dropId:gsub('%D', '')), 'drop',
-        slots or shared.dropslots, 0, maxWeight or shared.dropweight, false, {})
+	local dropId = generateInvId()
+	local inventory = Inventory.Create(dropId, ('%s %s'):format(prefix, dropId:gsub('%D', '')), 'drop',
+		slots or shared.dropslots, 0, maxWeight or shared.dropweight, false, {})
 
-    if not inventory then return end
+	if not inventory then return end
 
-    inventory.items, inventory.weight = generateItems(inventory, 'drop', items)
-    inventory.coords = coords
-    Inventory.Drops[dropId] = {
-        coords = inventory.coords,
-        instance = instance,
-        model = model,
-    }
+	inventory.items, inventory.weight = generateItems(inventory, 'drop', items)
+	inventory.coords = coords
+	Inventory.Drops[dropId] = {
+		coords = inventory.coords,
+		instance = instance,
+		model = model,
+	}
 
-    TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId])
+	TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId])
 
-    return dropId
+	return dropId
 end
 
 AddEventHandler('ox_inventory:customDrop', CustomDrop)
 exports('CustomDrop', CustomDrop)
 
 exports('CreateDropFromPlayer', function(playerId)
-    local playerInventory = Inventory(playerId)
+	local playerInventory = Inventory(playerId)
 
-    if not playerInventory or not next(playerInventory.items) then return end
+	if not playerInventory or not next(playerInventory.items) then return end
 
-    local dropId = generateInvId()
-    local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop', playerInventory.slots,
-        playerInventory.weight, playerInventory.maxWeight, false, table.clone(playerInventory.items))
+	local dropId = generateInvId()
+	local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop', playerInventory.slots,
+		playerInventory.weight, playerInventory.maxWeight, false, table.clone(playerInventory.items))
 
-    if not inventory then return end
+	if not inventory then return end
 
-    local coords = GetEntityCoords(GetPlayerPed(playerId))
-    inventory.coords = vec3(coords.x, coords.y, coords.z - 0.2)
-    Inventory.Drops[dropId] = {
-        coords = inventory.coords,
-        instance = Player(playerId).state.instance
-    }
+	local coords = GetEntityCoords(GetPlayerPed(playerId))
+	inventory.coords = vec3(coords.x, coords.y, coords.z - 0.2)
+	Inventory.Drops[dropId] = {
+		coords = inventory.coords,
+		instance = Player(playerId).state.instance
+	}
 
-    Inventory.Clear(playerInventory)
-    TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId])
+	Inventory.Clear(playerInventory)
+	TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId])
 
-    return dropId
+	return dropId
 end)
 
 local TriggerEventHooks = require 'modules.hooks.server'
@@ -1660,77 +1660,77 @@ local TriggerEventHooks = require 'modules.hooks.server'
 ---@param fromData SlotWithItem?
 ---@param data SwapSlotData
 local function dropItem(source, playerInventory, fromData, data)
-    if not fromData then return end
+	if not fromData then return end
 
-    local toData = table.clone(fromData)
-    toData.slot = data.toSlot
-    toData.count = data.count
-    toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
+	local toData = table.clone(fromData)
+	toData.slot = data.toSlot
+	toData.count = data.count
+	toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
 
-    if toData.weight > shared.dropweight then return end
+	if toData.weight > shared.dropweight then return end
 
-    local dropId = generateInvId('drop')
+	local dropId = generateInvId('drop')
 
-    if not TriggerEventHooks('swapItems', {
-            source = source,
-            fromInventory = playerInventory.id,
-            fromSlot = fromData,
-            fromType = playerInventory.type,
-            toInventory = 'newdrop',
-            toSlot = data.toSlot,
-            toType = 'drop',
-            count = data.count,
-            action = 'move',
-            dropId = dropId,
-        }) then
-        return
-    end
+	if not TriggerEventHooks('swapItems', {
+			source = source,
+			fromInventory = playerInventory.id,
+			fromSlot = fromData,
+			fromType = playerInventory.type,
+			toInventory = 'newdrop',
+			toSlot = data.toSlot,
+			toType = 'drop',
+			count = data.count,
+			action = 'move',
+			dropId = dropId,
+		}) then
+		return
+	end
 
-    fromData.count -= data.count
-    fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
+	fromData.count -= data.count
+	fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
 
-    if fromData.count < 1 then
-        fromData = nil
-    else
-        toData.metadata = table.clone(toData.metadata)
-    end
+	if fromData.count < 1 then
+		fromData = nil
+	else
+		toData.metadata = table.clone(toData.metadata)
+	end
 
-    local slot = data.fromSlot
-    playerInventory.weight -= toData.weight
-    playerInventory.items[slot] = fromData
+	local slot = data.fromSlot
+	playerInventory.weight -= toData.weight
+	playerInventory.items[slot] = fromData
 
-    if slot == playerInventory.weapon then
-        playerInventory.weapon = nil
-    end
+	if slot == playerInventory.weapon then
+		playerInventory.weapon = nil
+	end
 
-    local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop', shared.dropslots,
-        toData.weight, shared.dropweight, false, { [data.toSlot] = toData })
+	local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop', shared.dropslots,
+		toData.weight, shared.dropweight, false, { [data.toSlot] = toData })
 
-    if not inventory then return end
+	if not inventory then return end
 
-    inventory.coords = data.coords
-    Inventory.Drops[dropId] = { coords = inventory.coords, instance = data.instance }
-    playerInventory.changed = true
+	inventory.coords = data.coords
+	Inventory.Drops[dropId] = { coords = inventory.coords, instance = data.instance }
+	playerInventory.changed = true
 
-    TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId], playerInventory.open and source,
-        slot)
+	TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId], playerInventory.open and source,
+		slot)
 
-    if server.loglevel > 0 then
-        lib.logger(playerInventory.owner, 'swapSlots',
-            ('%sx %s transferred from "%s" to "%s"'):format(data.count, toData.name, playerInventory.label, dropId))
-    end
+	if server.loglevel > 0 then
+		lib.logger(playerInventory.owner, 'swapSlots',
+			('%sx %s transferred from "%s" to "%s"'):format(data.count, toData.name, playerInventory.label, dropId))
+	end
 
-    if server.syncInventory then server.syncInventory(playerInventory) end
+	if server.syncInventory then server.syncInventory(playerInventory) end
 
-    return true, {
-        weight = playerInventory.weight,
-        items = {
-            {
-                item = fromData or { slot = data.fromSlot },
-                inventory = playerInventory.id
-            }
-        }
-    }
+	return true, {
+		weight = playerInventory.weight,
+		items = {
+			{
+				item = fromData or { slot = data.fromSlot },
+				inventory = playerInventory.id
+			}
+		}
+	}
 end
 
 local activeSlots = {}
@@ -1738,303 +1738,303 @@ local activeSlots = {}
 ---@param source number
 ---@param data SwapSlotData
 lib.callback.register('ox_inventory:swapItems', function(source, data)
-    if data.count < 1 then return end
+	if data.count < 1 then return end
 
-    local playerInventory = Inventory(source)
-    if not playerInventory then return end
+	local playerInventory = Inventory(source)
+	if not playerInventory then return end
 
-    local toInventory = (data.toType == 'player' and playerInventory) or Inventory(playerInventory.open)
-    local fromInventory = (data.fromType == 'player' and playerInventory) or Inventory(playerInventory.open)
+	local toInventory = (data.toType == 'player' and playerInventory) or Inventory(playerInventory.open)
+	local fromInventory = (data.fromType == 'player' and playerInventory) or Inventory(playerInventory.open)
 
-    if not fromInventory or not toInventory then
-        playerInventory:closeInventory()
-        return
-    end
+	if not fromInventory or not toInventory then
+		playerInventory:closeInventory()
+		return
+	end
 
-    if data.toType == 'inspect' or data.fromType == 'inspect' then return end
+	if data.toType == 'inspect' or data.fromType == 'inspect' then return end
 
-    local fromRef = ('%s:%s'):format(fromInventory.id, data.fromSlot)
-    local toRef = ('%s:%s'):format(toInventory.id, data.toSlot)
+	local fromRef = ('%s:%s'):format(fromInventory.id, data.fromSlot)
+	local toRef = ('%s:%s'):format(toInventory.id, data.toSlot)
 
-    if activeSlots[fromRef] or activeSlots[toRef] then
-        return false, {
-            { item = toInventory.items[data.toSlot] or { slot = data.toSlot },       inventory = toInventory.id },
-            { item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
-        }
-    end
+	if activeSlots[fromRef] or activeSlots[toRef] then
+		return false, {
+			{ item = toInventory.items[data.toSlot] or { slot = data.toSlot },       inventory = toInventory.id },
+			{ item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
+		}
+	end
 
-    local sameInventory = fromInventory.id == toInventory.id
-    local fromOtherPlayer = fromInventory.player and fromInventory ~= playerInventory
-    local toOtherPlayer = toInventory.player and toInventory ~= playerInventory
-    local toData = toInventory.items[data.toSlot]
+	local sameInventory = fromInventory.id == toInventory.id
+	local fromOtherPlayer = fromInventory.player and fromInventory ~= playerInventory
+	local toOtherPlayer = toInventory.player and toInventory ~= playerInventory
+	local toData = toInventory.items[data.toSlot]
 
-    if not sameInventory and (fromInventory.type == 'policeevidence' or (toInventory.type == 'policeevidence' and toData)) then
-        local group, rank = server.hasGroup(playerInventory, shared.police)
-        if not group or server.evidencegrade > rank then
-            return false, 'evidence_cannot_take'
-        end
-    end
+	if not sameInventory and (fromInventory.type == 'policeevidence' or (toInventory.type == 'policeevidence' and toData)) then
+		local group, rank = server.hasGroup(playerInventory, shared.police)
+		if not group or server.evidencegrade > rank then
+			return false, 'evidence_cannot_take'
+		end
+	end
 
-    activeSlots[fromRef] = true
-    activeSlots[toRef] = true
+	activeSlots[fromRef] = true
+	activeSlots[toRef] = true
 
-    local _ <close> = defer(function()
-        activeSlots[fromRef] = nil
-        activeSlots[toRef] = nil
-    end)
+	local _ <close> = defer(function()
+		activeSlots[fromRef] = nil
+		activeSlots[toRef] = nil
+	end)
 
-    if toInventory and (data.toType == 'newdrop' or fromInventory ~= toInventory or data.fromSlot ~= data.toSlot) then
-        local fromData = fromInventory.items[data.fromSlot]
+	if toInventory and (data.toType == 'newdrop' or fromInventory ~= toInventory or data.fromSlot ~= data.toSlot) then
+		local fromData = fromInventory.items[data.fromSlot]
 
-        if not fromData then
-            return false, {
-                { item = { slot = data.fromSlot },         inventory = fromInventory.id },
-                { item = toData or { slot = data.toSlot }, inventory = toInventory.id }
-            }
-        end
+		if not fromData then
+			return false, {
+				{ item = { slot = data.fromSlot },         inventory = fromInventory.id },
+				{ item = toData or { slot = data.toSlot }, inventory = toInventory.id }
+			}
+		end
 
-        if data.count > fromData.count then
-            data.count = fromData.count
-        end
+		if data.count > fromData.count then
+			data.count = fromData.count
+		end
 
-        if data.toType == 'newdrop' then
-            return dropItem(source, playerInventory, fromData, data)
-        end
+		if data.toType == 'newdrop' then
+			return dropItem(source, playerInventory, fromData, data)
+		end
 
-        if fromData then
-            if fromData.metadata.container and toInventory.type == 'container' then return false end
-            if toData and toData.metadata.container and fromInventory.type == 'container' then return false end
+		if fromData then
+			if fromData.metadata.container and toInventory.type == 'container' then return false end
+			if toData and toData.metadata.container and fromInventory.type == 'container' then return false end
 
-            local container, containerItem = (not sameInventory and playerInventory.containerSlot) and
-                (fromInventory.type == 'container' and fromInventory or toInventory)
+			local container, containerItem = (not sameInventory and playerInventory.containerSlot) and
+				(fromInventory.type == 'container' and fromInventory or toInventory)
 
-            if container then
-                containerItem = playerInventory.items[playerInventory.containerSlot]
-            end
+			if container then
+				containerItem = playerInventory.items[playerInventory.containerSlot]
+			end
 
-            local hookPayload = {
-                source = source,
-                fromInventory = fromInventory.id,
-                fromSlot = fromData,
-                fromType = fromInventory.type,
-                toInventory = toInventory.id,
-                toSlot = toData or data.toSlot,
-                toType = toInventory.type,
-                count = data.count,
-            }
+			local hookPayload = {
+				source = source,
+				fromInventory = fromInventory.id,
+				fromSlot = fromData,
+				fromType = fromInventory.type,
+				toInventory = toInventory.id,
+				toSlot = toData or data.toSlot,
+				toType = toInventory.type,
+				count = data.count,
+			}
 
-            if toData and ((toData.name ~= fromData.name) or not toData.stack or (not table.matches(toData.metadata, fromData.metadata))) then
-                local toWeight = not sameInventory and (toInventory.weight - toData.weight + fromData.weight) or 0
-                local fromWeight = not sameInventory and (fromInventory.weight + toData.weight - fromData.weight) or 0
-                hookPayload.action = 'swap'
+			if toData and ((toData.name ~= fromData.name) or not toData.stack or (not table.matches(toData.metadata, fromData.metadata))) then
+				local toWeight = not sameInventory and (toInventory.weight - toData.weight + fromData.weight) or 0
+				local fromWeight = not sameInventory and (fromInventory.weight + toData.weight - fromData.weight) or 0
+				hookPayload.action = 'swap'
 
-                if not sameInventory then
-                    if (toWeight <= toInventory.maxWeight and fromWeight <= fromInventory.maxWeight) then
-                        if not TriggerEventHooks('swapItems', hookPayload) then return end
-                        if containerItem then
-                            local toContainer = toInventory.type == 'container'
-                            local whitelist = Items.containers[containerItem.name]?.whitelist
-                            local blacklist = Items.containers[containerItem.name]?.blacklist
-                            local checkItem = toContainer and fromData.name or toData.name
-                            if (whitelist and not whitelist[checkItem]) or (blacklist and blacklist[checkItem]) then return end
-                            Inventory.ContainerWeight(containerItem, toContainer and toWeight or fromWeight,
-                                playerInventory)
-                        end
-                        fromInventory.weight = fromWeight
-                        toInventory.weight = toWeight
-                        toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
-                    else
-                        return false, 'cannot_carry'
-                    end
-                else
-                    if not TriggerEventHooks('swapItems', hookPayload) then return end
-                    toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
-                end
-            elseif toData and toData.name == fromData.name and table.matches(toData.metadata, fromData.metadata) then
-                local maxStack = (type(toData.stack) == 'number' and toData.stack) or false
-                if maxStack then
-                    local spaceLeft = maxStack - toData.count
-                    if spaceLeft <= 0 then return false, 'stack_full' end
+				if not sameInventory then
+					if (toWeight <= toInventory.maxWeight and fromWeight <= fromInventory.maxWeight) then
+						if not TriggerEventHooks('swapItems', hookPayload) then return end
+						if containerItem then
+							local toContainer = toInventory.type == 'container'
+							local whitelist = Items.containers[containerItem.name]?.whitelist
+							local blacklist = Items.containers[containerItem.name]?.blacklist
+							local checkItem = toContainer and fromData.name or toData.name
+							if (whitelist and not whitelist[checkItem]) or (blacklist and blacklist[checkItem]) then return end
+							Inventory.ContainerWeight(containerItem, toContainer and toWeight or fromWeight,
+								playerInventory)
+						end
+						fromInventory.weight = fromWeight
+						toInventory.weight = toWeight
+						toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
+					else
+						return false, 'cannot_carry'
+					end
+				else
+					if not TriggerEventHooks('swapItems', hookPayload) then return end
+					toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
+				end
+			elseif toData and toData.name == fromData.name and table.matches(toData.metadata, fromData.metadata) then
+				local maxStack = (type(toData.stack) == 'number' and toData.stack) or false
+				if maxStack then
+					local spaceLeft = maxStack - toData.count
+					if spaceLeft <= 0 then return false, 'stack_full' end
 
-                    local moveAmount = math.min(data.count, fromData.count, spaceLeft)
-                    toData.count = toData.count + moveAmount
-                    fromData.count = fromData.count - moveAmount
-                    if fromData.count > 0 then
-                        toData.metadata = table.clone(toData.metadata)
-                        fromData.metadata = table.clone(fromData.metadata)
-                    end
-                    toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
-                    fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
-                    hookPayload.action = 'stackItems'
-                    hookPayload.moved = moveAmount
-                    hookPayload.leftover = data.count - moveAmount
-                    if not TriggerEventHooks('swapItems', hookPayload) then return end
-                else
-                    local tempCount, tempWeight = toData.count, toData.weight
-                    toData.count = fromData.count
-                    toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
-                    fromData.count = tempCount
-                    fromData.weight = tempWeight
+					local moveAmount = math.min(data.count, fromData.count, spaceLeft)
+					toData.count = toData.count + moveAmount
+					fromData.count = fromData.count - moveAmount
+					if fromData.count > 0 then
+						toData.metadata = table.clone(toData.metadata)
+						fromData.metadata = table.clone(fromData.metadata)
+					end
+					toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
+					fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
+					hookPayload.action = 'stackItems'
+					hookPayload.moved = moveAmount
+					hookPayload.leftover = data.count - moveAmount
+					if not TriggerEventHooks('swapItems', hookPayload) then return end
+				else
+					local tempCount, tempWeight = toData.count, toData.weight
+					toData.count = fromData.count
+					toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
+					fromData.count = tempCount
+					fromData.weight = tempWeight
 
-                    hookPayload.action = 'swapCounts'
-                    if not TriggerEventHooks('swapItems', hookPayload) then return end
-                end
-            elseif data.count <= fromData.count then
-                toData = table.clone(fromData)
-                toData.count = data.count
-                toData.slot = data.toSlot
-                toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
-                if fromInventory.type == 'container' or sameInventory or (toInventory.weight + toData.weight <= toInventory.maxWeight) then
-                    hookPayload.action = 'move'
-                    if not TriggerEventHooks('swapItems', hookPayload) then return end
-                    fromInventory.weight -= toData.weight
-                    toInventory.weight += toData.weight
-                    fromData.count -= data.count
-                    fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
-                    if fromData.count > 0 then
-                        toData.metadata = table.clone(toData.metadata)
-                    end
-                else
-                    return false, 'cannot_carry_other'
-                end
-            end
+					hookPayload.action = 'swapCounts'
+					if not TriggerEventHooks('swapItems', hookPayload) then return end
+				end
+			elseif data.count <= fromData.count then
+				toData = table.clone(fromData)
+				toData.count = data.count
+				toData.slot = data.toSlot
+				toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
+				if fromInventory.type == 'container' or sameInventory or (toInventory.weight + toData.weight <= toInventory.maxWeight) then
+					hookPayload.action = 'move'
+					if not TriggerEventHooks('swapItems', hookPayload) then return end
+					fromInventory.weight -= toData.weight
+					toInventory.weight += toData.weight
+					fromData.count -= data.count
+					fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
+					if fromData.count > 0 then
+						toData.metadata = table.clone(toData.metadata)
+					end
+				else
+					return false, 'cannot_carry_other'
+				end
+			end
 
-            if fromData and fromData.count < 1 then fromData = nil end
+			if fromData and fromData.count < 1 then fromData = nil end
 
-            local items = {}
-            if fromInventory.player and not fromOtherPlayer then
-                if toInventory.type == 'container' and containerItem then
-                    items[#items + 1] = { item = containerItem, inventory = playerInventory.id }
-                end
-            end
-            if toInventory.player and not toOtherPlayer then
-                if fromInventory.type == 'container' and containerItem then
-                    items[#items + 1] = { item = containerItem, inventory = playerInventory.id }
-                end
-            end
+			local items = {}
+			if fromInventory.player and not fromOtherPlayer then
+				if toInventory.type == 'container' and containerItem then
+					items[#items + 1] = { item = containerItem, inventory = playerInventory.id }
+				end
+			end
+			if toInventory.player and not toOtherPlayer then
+				if fromInventory.type == 'container' and containerItem then
+					items[#items + 1] = { item = containerItem, inventory = playerInventory.id }
+				end
+			end
 
-            fromInventory.items[data.fromSlot] = fromData
-            toInventory.items[data.toSlot] = toData
+			fromInventory.items[data.fromSlot] = fromData
+			toInventory.items[data.toSlot] = toData
 
-            if fromInventory.changed ~= nil then fromInventory.changed = true end
-            if toInventory.changed ~= nil then toInventory.changed = true end
+			if fromInventory.changed ~= nil then fromInventory.changed = true end
+			if toInventory.changed ~= nil then toInventory.changed = true end
 
-            CreateThread(function()
-                if sameInventory then
-                    fromInventory:syncSlotsWithClients({
-                        { item = fromInventory.items[data.toSlot] or { slot = data.toSlot },     inventory = fromInventory.id },
-                        { item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
-                    }, true)
-                else
-                    toInventory:syncSlotsWithClients({
-                        { item = toInventory.items[data.toSlot] or { slot = data.toSlot }, inventory = toInventory.id }
-                    }, true)
-                    fromInventory:syncSlotsWithClients({
-                        { item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
-                    }, true)
-                end
-            end)
+			CreateThread(function()
+				if sameInventory then
+					fromInventory:syncSlotsWithClients({
+						{ item = fromInventory.items[data.toSlot] or { slot = data.toSlot },     inventory = fromInventory.id },
+						{ item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
+					}, true)
+				else
+					toInventory:syncSlotsWithClients({
+						{ item = toInventory.items[data.toSlot] or { slot = data.toSlot }, inventory = toInventory.id }
+					}, true)
+					fromInventory:syncSlotsWithClients({
+						{ item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
+					}, true)
+				end
+			end)
 
-            local resp
-            if next(items) then
-                resp = { weight = playerInventory.weight, items = items }
-            end
+			local resp
+			if next(items) then
+				resp = { weight = playerInventory.weight, items = items }
+			end
 
-            if server.syncInventory then
-                if fromInventory.player then server.syncInventory(fromInventory) end
-                if toInventory.player and not sameInventory then server.syncInventory(toInventory) end
-            end
+			if server.syncInventory then
+				if fromInventory.player then server.syncInventory(fromInventory) end
+				if toInventory.player and not sameInventory then server.syncInventory(toInventory) end
+			end
 
-            local weaponSlot
-            if toInventory.weapon == data.toSlot then
-                if not sameInventory then
-                    toInventory.weapon = nil
-                    TriggerClientEvent('ox_inventory:disarm', toInventory.id)
-                else
-                    weaponSlot = data.fromSlot
-                    toInventory.weapon = weaponSlot
-                end
-            end
-            if fromInventory.weapon == data.fromSlot then
-                if not sameInventory then
-                    fromInventory.weapon = nil
-                    TriggerClientEvent('ox_inventory:disarm', fromInventory.id)
-                elseif not weaponSlot then
-                    weaponSlot = data.toSlot
-                    fromInventory.weapon = weaponSlot
-                end
-            end
+			local weaponSlot
+			if toInventory.weapon == data.toSlot then
+				if not sameInventory then
+					toInventory.weapon = nil
+					TriggerClientEvent('ox_inventory:disarm', toInventory.id)
+				else
+					weaponSlot = data.fromSlot
+					toInventory.weapon = weaponSlot
+				end
+			end
+			if fromInventory.weapon == data.fromSlot then
+				if not sameInventory then
+					fromInventory.weapon = nil
+					TriggerClientEvent('ox_inventory:disarm', fromInventory.id)
+				elseif not weaponSlot then
+					weaponSlot = data.toSlot
+					fromInventory.weapon = weaponSlot
+				end
+			end
 
-            return containerItem and containerItem.weight or true, resp, weaponSlot
-        end
-    end
+			return containerItem and containerItem.weight or true, resp, weaponSlot
+		end
+	end
 end)
 
 function Inventory.Confiscate(source)
-    local inv = Inventory(source)
+	local inv = Inventory(source)
 
-    if inv?.player then
-        db.saveStash(inv.owner, inv.owner, json.encode(minimal(inv)))
-        table.wipe(inv.items)
-        inv.weight = 0
-        inv.changed = true
+	if inv?.player then
+		db.saveStash(inv.owner, inv.owner, json.encode(minimal(inv)))
+		table.wipe(inv.items)
+		inv.weight = 0
+		inv.changed = true
 
-        TriggerClientEvent('ox_inventory:inventoryConfiscated', inv.id)
+		TriggerClientEvent('ox_inventory:inventoryConfiscated', inv.id)
 
-        if server.syncInventory then server.syncInventory(inv) end
-    end
+		if server.syncInventory then server.syncInventory(inv) end
+	end
 end
 
 exports('ConfiscateInventory', Inventory.Confiscate)
 
 function Inventory.Return(source)
-    local inv = Inventory(source)
+	local inv = Inventory(source)
 
-    if not inv?.player then return end
+	if not inv?.player then return end
 
-    local items = MySQL.scalar.await('SELECT data FROM ox_inventory WHERE name = ?', { inv.owner })
+	local items = MySQL.scalar.await('SELECT data FROM ox_inventory WHERE name = ?', { inv.owner })
 
-    if not items then return end
+	if not items then return end
 
-    MySQL.update.await('DELETE FROM ox_inventory WHERE name = ?', { inv.owner })
+	MySQL.update.await('DELETE FROM ox_inventory WHERE name = ?', { inv.owner })
 
-    items = json.decode(items)
-    local inventory, totalWeight = {}, 0
+	items = json.decode(items)
+	local inventory, totalWeight = {}, 0
 
-    if table.type(items) == 'array' then
-        for i = 1, #items do
-            local data = items[i]
-            if type(data) == 'number' then break end
+	if table.type(items) == 'array' then
+		for i = 1, #items do
+			local data = items[i]
+			if type(data) == 'number' then break end
 
-            local item = Items(data.name)
+			local item = Items(data.name)
 
-            if item then
-                local weight = Inventory.SlotWeight(item, data)
-                totalWeight = totalWeight + weight
-                inventory[data.slot] = {
-                    name = data.name,
-                    label = item.label,
-                    weight = weight,
-                    slot = data.slot,
-                    count =
-                        data.count,
-                    description = item.description,
-                    metadata = data.metadata,
-                    stack = item.stack,
-                    close = item
-                        .close
-                }
-            end
-        end
-    end
+			if item then
+				local weight = Inventory.SlotWeight(item, data)
+				totalWeight = totalWeight + weight
+				inventory[data.slot] = {
+					name = data.name,
+					label = item.label,
+					weight = weight,
+					slot = data.slot,
+					count =
+						data.count,
+					description = item.description,
+					metadata = data.metadata,
+					stack = item.stack,
+					close = item
+						.close
+				}
+			end
+		end
+	end
 
-    inv.changed = true
-    inv.weight = totalWeight
-    inv.items = inventory
+	inv.changed = true
+	inv.weight = totalWeight
+	inv.items = inventory
 
-    TriggerClientEvent('ox_inventory:inventoryReturned', source, { inventory, totalWeight })
+	TriggerClientEvent('ox_inventory:inventoryReturned', source, { inventory, totalWeight })
 
-    if server.syncInventory then server.syncInventory(inv) end
+	if server.syncInventory then server.syncInventory(inv) end
 end
 
 exports('ReturnInventory', Inventory.Return)
@@ -2042,82 +2042,82 @@ exports('ReturnInventory', Inventory.Return)
 ---@param inv inventory
 ---@param keep? string | string[] an item or list of items to ignore while clearing items
 function Inventory.Clear(inv, keep)
-    inv = Inventory(inv) --[[@as OxInventory]]
+	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if not inv or not next(inv.items) then return end
+	if not inv or not next(inv.items) then return end
 
-    local updateSlots = {}
-    local newWeight = 0
-    local inc = 0
+	local updateSlots = {}
+	local newWeight = 0
+	local inc = 0
 
-    if keep then
-        local keptItems = {}
-        local keepType = type(keep)
+	if keep then
+		local keptItems = {}
+		local keepType = type(keep)
 
-        if keepType == 'string' then
-            for slot, v in pairs(inv.items) do
-                if v.name == keep then
-                    keptItems[v.slot] = v
-                    newWeight += v.weight
-                elseif updateSlots then
-                    inc += 1
-                    updateSlots[inc] = { item = { slot = slot }, inventory = inv.id }
-                end
-            end
-        elseif keepType == 'table' and table.type(keep) == 'array' then
-            for slot, v in pairs(inv.items) do
-                for i = 1, #keep do
-                    if v.name == keep[i] then
-                        keptItems[v.slot] = v
-                        newWeight += v.weight
-                        goto foundItem
-                    end
-                end
+		if keepType == 'string' then
+			for slot, v in pairs(inv.items) do
+				if v.name == keep then
+					keptItems[v.slot] = v
+					newWeight += v.weight
+				elseif updateSlots then
+					inc += 1
+					updateSlots[inc] = { item = { slot = slot }, inventory = inv.id }
+				end
+			end
+		elseif keepType == 'table' and table.type(keep) == 'array' then
+			for slot, v in pairs(inv.items) do
+				for i = 1, #keep do
+					if v.name == keep[i] then
+						keptItems[v.slot] = v
+						newWeight += v.weight
+						goto foundItem
+					end
+				end
 
-                if updateSlots then
-                    inc += 1
-                    updateSlots[inc] = { item = { slot = slot }, inventory = inv.id }
-                end
+				if updateSlots then
+					inc += 1
+					updateSlots[inc] = { item = { slot = slot }, inventory = inv.id }
+				end
 
-                ::foundItem::
-            end
-        end
+				::foundItem::
+			end
+		end
 
-        table.wipe(inv.items)
-        inv.items = keptItems
-    else
-        if updateSlots then
-            for slot in pairs(inv.items) do
-                inc += 1
-                updateSlots[inc] = { item = { slot = slot }, inventory = inv.id }
-            end
-        end
+		table.wipe(inv.items)
+		inv.items = keptItems
+	else
+		if updateSlots then
+			for slot in pairs(inv.items) do
+				inc += 1
+				updateSlots[inc] = { item = { slot = slot }, inventory = inv.id }
+			end
+		end
 
-        table.wipe(inv.items)
-    end
+		table.wipe(inv.items)
+	end
 
-    inv.weight = newWeight
-    inv.changed = true
+	inv.weight = newWeight
+	inv.changed = true
 
-    inv:syncSlotsWithClients(updateSlots, true)
+	inv:syncSlotsWithClients(updateSlots, true)
 
-    if not inv.player then
-        if inv.open then
-            local playerInv = Inventory(inv.open)
+	if not inv.player then
+		if inv.open then
+			local playerInv = Inventory(inv.open)
 
-            if not playerInv then return end
+			if not playerInv then return end
 
-            playerInv:closeInventory()
-        end
+			playerInv:closeInventory()
+		end
 
-        inv:openInventory(inv)
+		inv:openInventory(inv)
 
-        return
-    end
+		return
+	end
 
-    if server.syncInventory then server.syncInventory(inv) end
+	if server.syncInventory then server.syncInventory(inv) end
 
-    inv.weapon = nil
+	inv.weapon = nil
 end
 
 exports('ClearInventory', Inventory.Clear)
@@ -2125,17 +2125,17 @@ exports('ClearInventory', Inventory.Clear)
 ---@param inv inventory
 ---@return integer?
 function Inventory.GetEmptySlot(inv)
-    local inventory = Inventory(inv)
+	local inventory = Inventory(inv)
 
-    if not inventory then return end
+	if not inventory then return end
 
-    local items = inventory.items
+	local items = inventory.items
 
-    for i = 1, inventory.slots do
-        if not items[i] then
-            return i
-        end
-    end
+	for i = 1, inventory.slots do
+		if not items[i] then
+			return i
+		end
+	end
 end
 
 exports('GetEmptySlot', Inventory.GetEmptySlot)
@@ -2144,28 +2144,28 @@ exports('GetEmptySlot', Inventory.GetEmptySlot)
 ---@param itemName string
 ---@param metadata any
 function Inventory.GetSlotForItem(inv, itemName, metadata)
-    local inventory = Inventory(inv)
-    local item = Items(itemName) --[[@as OxServerItem?]]
+	local inventory = Inventory(inv)
+	local item = Items(itemName) --[[@as OxServerItem?]]
 
-    if not inventory or not item then return end
+	if not inventory or not item then return end
 
-    metadata = assertMetadata(metadata)
-    local items = inventory.items
-    local emptySlot
+	metadata = assertMetadata(metadata)
+	local items = inventory.items
+	local emptySlot
 
-    for i = 1, inventory.slots do
-        local slotData = items[i]
+	for i = 1, inventory.slots do
+		local slotData = items[i]
 
-        if item.stack and slotData and slotData.name == item.name and table.matches(slotData.metadata, metadata) then
-            if slotData.count < (slotData.stack or item.stack) then
-                return i
-            end
-        elseif not slotData and not emptySlot then
-            emptySlot = i
-        end
-    end
+		if item.stack and slotData and slotData.name == item.name and table.matches(slotData.metadata, metadata) then
+			if slotData.count < (slotData.stack or item.stack) then
+				return i
+			end
+		elseif not slotData and not emptySlot then
+			emptySlot = i
+		end
+	end
 
-    return emptySlot
+	return emptySlot
 end
 
 exports('GetSlotForItem', Inventory.GetSlotForItem)
@@ -2176,21 +2176,21 @@ exports('GetSlotForItem', Inventory.GetSlotForItem)
 ---@param strict? boolean Strictly match metadata properties, otherwise use partial matching.
 ---@return SlotWithItem?
 function Inventory.GetSlotWithItem(inv, itemName, metadata, strict)
-    local inventory = Inventory(inv)
-    local item = Items(itemName) --[[@as OxServerItem?]]
+	local inventory = Inventory(inv)
+	local item = Items(itemName) --[[@as OxServerItem?]]
 
-    if not inventory or not item then return end
+	if not inventory or not item then return end
 
-    metadata = assertMetadata(metadata)
-    local tablematch = strict and table.matches or table.contains
+	metadata = assertMetadata(metadata)
+	local tablematch = strict and table.matches or table.contains
 
-    for _, slotData in pairs(inventory.items) do
-        if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
-            if not Items.UpdateDurability(inventory, slotData, item, nil, os.time()) then
-                return slotData
-            end
-        end
-    end
+	for _, slotData in pairs(inventory.items) do
+		if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
+			if not Items.UpdateDurability(inventory, slotData, item, nil, os.time()) then
+				return slotData
+			end
+		end
+	end
 end
 
 exports('GetSlotWithItem', Inventory.GetSlotWithItem)
@@ -2201,7 +2201,7 @@ exports('GetSlotWithItem', Inventory.GetSlotWithItem)
 ---@param strict? boolean Strictly match metadata properties, otherwise use partial matching.
 ---@return number?
 function Inventory.GetSlotIdWithItem(inv, itemName, metadata, strict)
-    return Inventory.GetSlotWithItem(inv, itemName, metadata, strict)?.slot
+	return Inventory.GetSlotWithItem(inv, itemName, metadata, strict)?.slot
 end
 
 exports('GetSlotIdWithItem', Inventory.GetSlotIdWithItem)
@@ -2212,26 +2212,26 @@ exports('GetSlotIdWithItem', Inventory.GetSlotIdWithItem)
 ---@param strict? boolean Strictly match metadata properties, otherwise use partial matching.
 ---@return SlotWithItem[]?
 function Inventory.GetSlotsWithItem(inv, itemName, metadata, strict)
-    local inventory = Inventory(inv)
-    local item = Items(itemName) --[[@as OxServerItem?]]
+	local inventory = Inventory(inv)
+	local item = Items(itemName) --[[@as OxServerItem?]]
 
-    if not inventory or not item then return end
+	if not inventory or not item then return end
 
-    metadata = assertMetadata(metadata)
-    local response = {}
-    local n = 0
-    local tablematch = strict and table.matches or table.contains
+	metadata = assertMetadata(metadata)
+	local response = {}
+	local n = 0
+	local tablematch = strict and table.matches or table.contains
 
-    for _, slotData in pairs(inventory.items) do
-        if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
-            if not Items.UpdateDurability(inventory, slotData, item, nil, os.time()) then
-                n += 1
-                response[n] = slotData
-            end
-        end
-    end
+	for _, slotData in pairs(inventory.items) do
+		if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
+			if not Items.UpdateDurability(inventory, slotData, item, nil, os.time()) then
+				n += 1
+				response[n] = slotData
+			end
+		end
+	end
 
-    return response
+	return response
 end
 
 exports('GetSlotsWithItem', Inventory.GetSlotsWithItem)
@@ -2242,16 +2242,16 @@ exports('GetSlotsWithItem', Inventory.GetSlotsWithItem)
 ---@param strict? boolean Strictly match metadata properties, otherwise use partial matching.
 ---@return number[]?
 function Inventory.GetSlotIdsWithItem(inv, itemName, metadata, strict)
-    local items = Inventory.GetSlotsWithItem(inv, itemName, metadata, strict)
+	local items = Inventory.GetSlotsWithItem(inv, itemName, metadata, strict)
 
-    if items then
-        ---@cast items +number[]
-        for i = 1, #items do
-            items[i] = items[i].slot
-        end
+	if items then
+		---@cast items +number[]
+		for i = 1, #items do
+			items[i] = items[i].slot
+		end
 
-        return items
-    end
+		return items
+	end
 end
 
 exports('GetSlotIdsWithItem', Inventory.GetSlotIdsWithItem)
@@ -2262,22 +2262,22 @@ exports('GetSlotIdsWithItem', Inventory.GetSlotIdsWithItem)
 ---@param strict? boolean Strictly match metadata properties, otherwise use partial matching.
 ---@return number
 function Inventory.GetItemCount(inv, itemName, metadata, strict)
-    local inventory = Inventory(inv)
-    local item = Items(itemName) --[[@as OxServerItem?]]
+	local inventory = Inventory(inv)
+	local item = Items(itemName) --[[@as OxServerItem?]]
 
-    if not inventory or not item then return 0 end
+	if not inventory or not item then return 0 end
 
-    metadata = assertMetadata(metadata)
-    local count = 0
-    local tablematch = strict and table.matches or table.contains
+	metadata = assertMetadata(metadata)
+	local count = 0
+	local tablematch = strict and table.matches or table.contains
 
-    for _, slotData in pairs(inventory.items) do
-        if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
-            count += slotData.count
-        end
-    end
+	for _, slotData in pairs(inventory.items) do
+		if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
+			count += slotData.count
+		end
+	end
 
-    return count
+	return count
 end
 
 exports('GetItemCount', Inventory.GetItemCount)
@@ -2290,396 +2290,396 @@ exports('GetItemCount', Inventory.GetItemCount)
 ---@return integer?
 ---@return InventorySaveData?
 local function prepareInventorySave(inv, buffer, time)
-    local shouldSave = not inv.datastore and inv.changed
-    local n = 0
+	local shouldSave = not inv.datastore and inv.changed
+	local n = 0
 
-    for k, v in pairs(inv.items) do
-        if not Items.UpdateDurability(inv, v, Items(v.name), nil, time) and shouldSave then
-            n += 1
-            buffer[n] = {
-                name = v.name,
-                count = v.count,
-                slot = k,
-                metadata = next(v.metadata) and v.metadata or nil
-            }
-        end
-    end
+	for k, v in pairs(inv.items) do
+		if not Items.UpdateDurability(inv, v, Items(v.name), nil, time) and shouldSave then
+			n += 1
+			buffer[n] = {
+				name = v.name,
+				count = v.count,
+				slot = k,
+				metadata = next(v.metadata) and v.metadata or nil
+			}
+		end
+	end
 
-    if not shouldSave then return end
+	if not shouldSave then return end
 
-    local data = next(buffer) and json.encode(buffer) or nil
-    inv.changed = false
-    table.wipe(buffer)
+	local data = next(buffer) and json.encode(buffer) or nil
+	inv.changed = false
+	table.wipe(buffer)
 
-    if inv.player then
-        if shared.framework == 'esx' then return end
+	if inv.player then
+		if shared.framework == 'esx' then return end
 
-        return 1, { data, inv.owner }
-    end
+		return 1, { data, inv.owner }
+	end
 
-    if inv.type == 'trunk' then
-        return 2, { data, inv.dbId }
-    end
+	if inv.type == 'trunk' then
+		return 2, { data, inv.dbId }
+	end
 
-    if inv.type == 'glovebox' then
-        return 3, { data, inv.dbId }
-    end
+	if inv.type == 'glovebox' then
+		return 3, { data, inv.dbId }
+	end
 
-    return 4, { data, inv.owner and tostring(inv.owner) or '', inv.dbId }
+	return 4, { data, inv.owner and tostring(inv.owner) or '', inv.dbId }
 end
 
 local isSaving = false
 local inventoryClearTime = GetConvarInt('inventory:cleartime', 5) * 60
 
 local function saveInventories(clearInventories)
-    if isSaving then return end
+	if isSaving then return end
 
-    local time = os.time()
-    local parameters = { {}, {}, {}, {} }
-    local total = { 0, 0, 0, 0, 0 }
-    local buffer = {}
+	local time = os.time()
+	local parameters = { {}, {}, {}, {} }
+	local total = { 0, 0, 0, 0, 0 }
+	local buffer = {}
 
-    for _, inv in pairs(Inventories) do
-        local index, data = prepareInventorySave(inv, buffer, time)
+	for _, inv in pairs(Inventories) do
+		local index, data = prepareInventorySave(inv, buffer, time)
 
-        if index and data then
-            total[5] += 1
+		if index and data then
+			total[5] += 1
 
-            if index == 4 and server.bulkstashsave then
-                for i = 1, 3 do
-                    total[index] += 1
-                    parameters[index][total[index]] = data[i]
-                end
-            else
-                total[index] += 1
-                parameters[index][total[index]] = data
-            end
-        end
-    end
+			if index == 4 and server.bulkstashsave then
+				for i = 1, 3 do
+					total[index] += 1
+					parameters[index][total[index]] = data[i]
+				end
+			else
+				total[index] += 1
+				parameters[index][total[index]] = data
+			end
+		end
+	end
 
-    if total[5] > 0 then
-        isSaving = true
-        local ok, err = pcall(db.saveInventories, parameters[1], parameters[2], parameters[3], parameters[4], total)
-        isSaving = false
+	if total[5] > 0 then
+		isSaving = true
+		local ok, err = pcall(db.saveInventories, parameters[1], parameters[2], parameters[3], parameters[4], total)
+		isSaving = false
 
-        if not ok and err then return lib.print.error(err) end
-    end
+		if not ok and err then return lib.print.error(err) end
+	end
 
-    if not clearInventories then return end
+	if not clearInventories then return end
 
-    for _, inv in pairs(Inventories) do
-        if not inv.open and not inv.player then
-            -- clear inventory from memory if unused for x minutes, or on entity/netid mismatch
-            if inv.type == 'glovebox' or inv.type == 'trunk' then
-                if NetworkGetEntityFromNetworkId(inv.netid) ~= inv.entityId then
-                    Inventory.Remove(inv)
-                end
-            elseif time - inv.time >= inventoryClearTime then
-                Inventory.Remove(inv)
-            end
-        end
-    end
+	for _, inv in pairs(Inventories) do
+		if not inv.open and not inv.player then
+			-- clear inventory from memory if unused for x minutes, or on entity/netid mismatch
+			if inv.type == 'glovebox' or inv.type == 'trunk' then
+				if NetworkGetEntityFromNetworkId(inv.netid) ~= inv.entityId then
+					Inventory.Remove(inv)
+				end
+			elseif time - inv.time >= inventoryClearTime then
+				Inventory.Remove(inv)
+			end
+		end
+	end
 end
 
 lib.cron.new('*/5 * * * *', function()
-    saveInventories(true)
+	saveInventories(true)
 end)
 
 function Inventory.SaveInventories(lock, clearInventories)
-    Inventory.Lock = lock or nil
+	Inventory.Lock = lock or nil
 
-    Inventory.CloseAll()
-    saveInventories(clearInventories)
+	Inventory.CloseAll()
+	saveInventories(clearInventories)
 end
 
 AddEventHandler('playerDropped', function()
-    server.playerDropped(source)
+	server.playerDropped(source)
 
-    if GetNumPlayerIndices() == 0 then
-        Inventory.SaveInventories(false, true)
-    end
+	if GetNumPlayerIndices() == 0 then
+		Inventory.SaveInventories(false, true)
+	end
 end)
 
 AddEventHandler('txAdmin:events:serverShuttingDown', function()
-    Inventory.SaveInventories(true, false)
+	Inventory.SaveInventories(true, false)
 end)
 
 AddEventHandler('txAdmin:events:scheduledRestart', function(eventData)
-    if eventData.secondsRemaining ~= 60 then return end
+	if eventData.secondsRemaining ~= 60 then return end
 
-    Inventory.SaveInventories(true, true)
+	Inventory.SaveInventories(true, true)
 end)
 
 AddEventHandler('onResourceStop', function(resource)
-    if resource == shared.resource then
-        Inventory.SaveInventories(true, false)
-    end
+	if resource == shared.resource then
+		Inventory.SaveInventories(true, false)
+	end
 end)
 
 RegisterServerEvent('ox_inventory:closeInventory', function()
-    local inventory = Inventories[source]
+	local inventory = Inventories[source]
 
-    if inventory?.open then
-        local secondary = Inventories[inventory.open]
+	if inventory?.open then
+		local secondary = Inventories[inventory.open]
 
-        if secondary then
-            secondary:closeInventory()
-        end
+		if secondary then
+			secondary:closeInventory()
+		end
 
-        inventory:closeInventory(true)
-    end
+		inventory:closeInventory(true)
+	end
 end)
 
 local function giveItem(playerId, slot, target, count)
-    local fromInventory = Inventory(playerId)
-    local toInventory = Inventory(target)
+	local fromInventory = Inventory(playerId)
+	local toInventory = Inventory(target)
 
-    if not fromInventory or not toInventory then return end
+	if not fromInventory or not toInventory then return end
 
-    if type(count) ~= 'number' or count <= 0 then count = 1 end
+	if type(count) ~= 'number' or count <= 0 then count = 1 end
 
-    if toInventory.player then
-        local data = fromInventory.items[slot]
+	if toInventory.player then
+		local data = fromInventory.items[slot]
 
-        if not data then return end
+		if not data then return end
 
-        local targetState = Player(target).state
+		local targetState = Player(target).state
 
-        if targetState.invBusy then
-            return { 'cannot_give', count, data.label }
-        end
+		if targetState.invBusy then
+			return { 'cannot_give', count, data.label }
+		end
 
-        local item = Items(data.name)
+		local item = Items(data.name)
 
-        if not item or data.count < count or not Inventory.CanCarryItem(toInventory, item, count, data.metadata) or #(GetEntityCoords(fromInventory.player.ped) - GetEntityCoords(toInventory.player.ped)) > 15 then
-            return { 'cannot_give', count, data.label }
-        end
+		if not item or data.count < count or not Inventory.CanCarryItem(toInventory, item, count, data.metadata) or #(GetEntityCoords(fromInventory.player.ped) - GetEntityCoords(toInventory.player.ped)) > 15 then
+			return { 'cannot_give', count, data.label }
+		end
 
-        local toSlot = Inventory.GetSlotForItem(toInventory, data.name, data.metadata)
-        local fromRef = ('%s:%s'):format(fromInventory.id, slot)
-        local toRef = ('%s:%s'):format(toInventory.id, toSlot)
+		local toSlot = Inventory.GetSlotForItem(toInventory, data.name, data.metadata)
+		local fromRef = ('%s:%s'):format(fromInventory.id, slot)
+		local toRef = ('%s:%s'):format(toInventory.id, toSlot)
 
-        if activeSlots[fromRef] or activeSlots[toRef] then
-            return { 'cannot_give', count, data.label }
-        end
+		if activeSlots[fromRef] or activeSlots[toRef] then
+			return { 'cannot_give', count, data.label }
+		end
 
-        activeSlots[fromRef] = true
-        activeSlots[toRef] = true
+		activeSlots[fromRef] = true
+		activeSlots[toRef] = true
 
-        local _ <close> = defer(function()
-            activeSlots[fromRef] = nil
-            activeSlots[toRef] = nil
-        end)
+		local _ <close> = defer(function()
+			activeSlots[fromRef] = nil
+			activeSlots[toRef] = nil
+		end)
 
-        if TriggerEventHooks('swapItems', {
-                source = fromInventory.id,
-                fromInventory = fromInventory.id,
-                fromType = fromInventory.type,
-                toInventory = toInventory.id,
-                toType = toInventory.type,
-                count = count,
-                action = 'give',
-                fromSlot = data,
-            }) then
-            ---@todo manually call swapItems or something?
-            if Inventory.AddItem(toInventory, item, count, data.metadata, toSlot) then
-                if Inventory.RemoveItem(fromInventory, item, count, data.metadata, slot) then
-                    if server.loglevel > 0 then
-                        lib.logger(fromInventory.owner, 'giveItem',
-                            ('"%s" gave %sx %s to "%s"'):format(fromInventory.label, count, data.name, toInventory.label))
-                    end
+		if TriggerEventHooks('swapItems', {
+				source = fromInventory.id,
+				fromInventory = fromInventory.id,
+				fromType = fromInventory.type,
+				toInventory = toInventory.id,
+				toType = toInventory.type,
+				count = count,
+				action = 'give',
+				fromSlot = data,
+			}) then
+			---@todo manually call swapItems or something?
+			if Inventory.AddItem(toInventory, item, count, data.metadata, toSlot) then
+				if Inventory.RemoveItem(fromInventory, item, count, data.metadata, slot) then
+					if server.loglevel > 0 then
+						lib.logger(fromInventory.owner, 'giveItem',
+							('"%s" gave %sx %s to "%s"'):format(fromInventory.label, count, data.name, toInventory.label))
+					end
 
-                    return
-                else
-                    Inventory.RemoveItem(toInventory, item, count, data.metadata, toSlot)
-                end
-            end
-        end
+					return
+				else
+					Inventory.RemoveItem(toInventory, item, count, data.metadata, toSlot)
+				end
+			end
+		end
 
-        return { 'cannot_give', count, data.label }
-    end
+		return { 'cannot_give', count, data.label }
+	end
 end
 
 lib.callback.register('ox_inventory:giveItem', giveItem)
 RegisterServerEvent('ox_inventory:giveItem', function(...) giveItem(source, ...) end)
 
 local function updateWeapon(source, action, value, slot, specialAmmo)
-    local inventory = Inventory(source)
+	local inventory = Inventory(source)
 
-    if not inventory then return end
+	if not inventory then return end
 
-    if not action then
-        inventory.weapon = nil
-        return
-    end
+	if not action then
+		inventory.weapon = nil
+		return
+	end
 
-    local type = type(value)
+	local type = type(value)
 
-    if type == 'table' and action == 'component' then
-        local item = inventory.items[value.slot]
+	if type == 'table' and action == 'component' then
+		local item = inventory.items[value.slot]
 
-        if item then
-            if item.metadata.components then
-                for k, v in pairs(item.metadata.components) do
-                    if v == value.component then
-                        if not Inventory.AddItem(inventory, value.component, 1) then return end
+		if item then
+			if item.metadata.components then
+				for k, v in pairs(item.metadata.components) do
+					if v == value.component then
+						if not Inventory.AddItem(inventory, value.component, 1) then return end
 
-                        table.remove(item.metadata.components, k)
-                        inventory:syncSlotsWithPlayer({
-                            { item = item }
-                        }, inventory.weight)
+						table.remove(item.metadata.components, k)
+						inventory:syncSlotsWithPlayer({
+							{ item = item }
+						}, inventory.weight)
 
-                        if server.syncInventory then server.syncInventory(inventory) end
+						if server.syncInventory then server.syncInventory(inventory) end
 
-                        return true
-                    end
-                end
-            end
-        end
-    else
-        if not slot then slot = inventory.weapon end
-        local weapon = inventory.items[slot]
+						return true
+					end
+				end
+			end
+		end
+	else
+		if not slot then slot = inventory.weapon end
+		local weapon = inventory.items[slot]
 
-        if weapon and weapon.metadata then
-            local item = Items(weapon.name)
+		if weapon and weapon.metadata then
+			local item = Items(weapon.name)
 
-            if not item.weapon then
-                inventory.weapon = nil
-                return
-            end
+			if not item.weapon then
+				inventory.weapon = nil
+				return
+			end
 
-            if action == 'load' and weapon.metadata.durability > 0 then
-                local ammo = Items(weapon.name).ammoname
-                local diff = value - (weapon.metadata.ammo or 0)
+			if action == 'load' and weapon.metadata.durability > 0 then
+				local ammo = Items(weapon.name).ammoname
+				local diff = value - (weapon.metadata.ammo or 0)
 
-                if not Inventory.RemoveItem(inventory, ammo, diff, specialAmmo) then return end
+				if not Inventory.RemoveItem(inventory, ammo, diff, specialAmmo) then return end
 
-                weapon.metadata.ammo = value
-                weapon.metadata.specialAmmo = specialAmmo
-                weapon.weight = Inventory.SlotWeight(item, weapon)
-            elseif action == 'throw' then
-                if not Inventory.RemoveItem(inventory, weapon.name, 1, weapon.metadata, weapon.slot) then return end
-            elseif action == 'component' then
-                if type == 'number' then
-                    if not Inventory.AddItem(inventory, weapon.metadata.components[value], 1) then return false end
+				weapon.metadata.ammo = value
+				weapon.metadata.specialAmmo = specialAmmo
+				weapon.weight = Inventory.SlotWeight(item, weapon)
+			elseif action == 'throw' then
+				if not Inventory.RemoveItem(inventory, weapon.name, 1, weapon.metadata, weapon.slot) then return end
+			elseif action == 'component' then
+				if type == 'number' then
+					if not Inventory.AddItem(inventory, weapon.metadata.components[value], 1) then return false end
 
-                    table.remove(weapon.metadata.components, value)
-                    weapon.weight = Inventory.SlotWeight(item, weapon)
-                elseif type == 'string' then
-                    local component = inventory.items[tonumber(value)]
+					table.remove(weapon.metadata.components, value)
+					weapon.weight = Inventory.SlotWeight(item, weapon)
+				elseif type == 'string' then
+					local component = inventory.items[tonumber(value)]
 
-                    if not Inventory.RemoveItem(inventory, component.name, 1) then return false end
+					if not Inventory.RemoveItem(inventory, component.name, 1) then return false end
 
-                    table.insert(weapon.metadata.components, component.name)
-                    weapon.weight = Inventory.SlotWeight(item, weapon)
-                end
-            elseif action == 'ammo' then
-                if item.hash == `WEAPON_FIREEXTINGUISHER` or item.hash == `WEAPON_PETROLCAN` or item.hash == `WEAPON_HAZARDCAN` or item.hash == `WEAPON_FERTILIZERCAN` then
-                    weapon.metadata.durability = math.floor(value)
-                    weapon.metadata.ammo = weapon.metadata.durability
-                elseif value < weapon.metadata.ammo then
-                    local durability = Items(weapon.name).durability * math.abs((weapon.metadata.ammo or 0.1) - value)
-                    weapon.metadata.ammo = value
-                    weapon.metadata.durability = weapon.metadata.durability - durability
-                    weapon.weight = Inventory.SlotWeight(item, weapon)
-                end
-            elseif action == 'melee' and value > 0 then
-                weapon.metadata.durability = weapon.metadata.durability - ((Items(weapon.name).durability or 1) * value)
-            end
+					table.insert(weapon.metadata.components, component.name)
+					weapon.weight = Inventory.SlotWeight(item, weapon)
+				end
+			elseif action == 'ammo' then
+				if item.hash == `WEAPON_FIREEXTINGUISHER` or item.hash == `WEAPON_PETROLCAN` or item.hash == `WEAPON_HAZARDCAN` or item.hash == `WEAPON_FERTILIZERCAN` then
+					weapon.metadata.durability = math.floor(value)
+					weapon.metadata.ammo = weapon.metadata.durability
+				elseif value < weapon.metadata.ammo then
+					local durability = Items(weapon.name).durability * math.abs((weapon.metadata.ammo or 0.1) - value)
+					weapon.metadata.ammo = value
+					weapon.metadata.durability = weapon.metadata.durability - durability
+					weapon.weight = Inventory.SlotWeight(item, weapon)
+				end
+			elseif action == 'melee' and value > 0 then
+				weapon.metadata.durability = weapon.metadata.durability - ((Items(weapon.name).durability or 1) * value)
+			end
 
-            if (weapon.metadata.durability or 0) < 0 then
-                weapon.metadata.durability = 0
-            end
+			if (weapon.metadata.durability or 0) < 0 then
+				weapon.metadata.durability = 0
+			end
 
-            if item.hash == `WEAPON_PETROLCAN` then
-                weapon.weight = Inventory.SlotWeight(item, weapon)
-            end
+			if item.hash == `WEAPON_PETROLCAN` then
+				weapon.weight = Inventory.SlotWeight(item, weapon)
+			end
 
-            if action ~= 'throw' then
-                inventory:syncSlotsWithPlayer({
-                    { item = weapon }
-                }, inventory.weight)
-            end
+			if action ~= 'throw' then
+				inventory:syncSlotsWithPlayer({
+					{ item = weapon }
+				}, inventory.weight)
+			end
 
-            if server.syncInventory then server.syncInventory(inventory) end
+			if server.syncInventory then server.syncInventory(inventory) end
 
-            return true
-        end
-    end
+			return true
+		end
+	end
 end
 
 lib.callback.register('ox_inventory:updateWeapon', updateWeapon)
 
 RegisterNetEvent('ox_inventory:updateWeapon', function(action, value, slot, specialAmmo)
-    updateWeapon(source, action, value, slot, specialAmmo)
+	updateWeapon(source, action, value, slot, specialAmmo)
 end)
 
 lib.callback.register('ox_inventory:removeAmmoFromWeapon', function(source, slot)
-    local inventory = Inventory(source)
+	local inventory = Inventory(source)
 
-    if not inventory then return end
+	if not inventory then return end
 
-    local slotData = inventory.items[slot]
+	local slotData = inventory.items[slot]
 
-    if not slotData or not slotData.metadata.ammo or slotData.metadata.ammo < 1 then return end
+	if not slotData or not slotData.metadata.ammo or slotData.metadata.ammo < 1 then return end
 
-    local item = Items(slotData.name)
+	local item = Items(slotData.name)
 
-    if not item or not item.ammoname then return end
-    local specialAmmo = slotData.metadata.specialAmmo and { type = slotData.metadata.specialAmmo } or nil
+	if not item or not item.ammoname then return end
+	local specialAmmo = slotData.metadata.specialAmmo and { type = slotData.metadata.specialAmmo } or nil
 
 
-    if Inventory.AddItem(inventory, item.ammoname, slotData.metadata.ammo, specialAmmo) then
-        slotData.metadata.ammo = 0
-        slotData.weight = Inventory.SlotWeight(item, slotData)
+	if Inventory.AddItem(inventory, item.ammoname, slotData.metadata.ammo, specialAmmo) then
+		slotData.metadata.ammo = 0
+		slotData.weight = Inventory.SlotWeight(item, slotData)
 
-        inventory:syncSlotsWithPlayer({
-            { item = slotData }
-        }, inventory.weight)
+		inventory:syncSlotsWithPlayer({
+			{ item = slotData }
+		}, inventory.weight)
 
-        if server.syncInventory then server.syncInventory(inventory) end
+		if server.syncInventory then server.syncInventory(inventory) end
 
-        return true
-    end
+		return true
+	end
 end)
 
 local function checkStashProperties(properties)
-    local name = properties.name
-    local slots = properties.slots
-    local maxWeight = properties.maxWeight
-    local coords = properties.coords
+	local name = properties.name
+	local slots = properties.slots
+	local maxWeight = properties.maxWeight
+	local coords = properties.coords
 
-    if type(name) ~= 'string' then
-        error(('received %s for stash name (expected string)'):format(type(name)))
-    end
+	if type(name) ~= 'string' then
+		error(('received %s for stash name (expected string)'):format(type(name)))
+	end
 
-    if type(slots) ~= 'number' then
-        error(('received %s for stash slots (expected number)'):format(type(slots)))
-    end
+	if type(slots) ~= 'number' then
+		error(('received %s for stash slots (expected number)'):format(type(slots)))
+	end
 
-    if type(maxWeight) ~= 'number' then
-        error(('received %s for stash maxWeight (expected number)'):format(type(maxWeight)))
-    end
+	if type(maxWeight) ~= 'number' then
+		error(('received %s for stash maxWeight (expected number)'):format(type(maxWeight)))
+	end
 
-    if coords then
-        local typeof = type(coords)
+	if coords then
+		local typeof = type(coords)
 
-        if typeof ~= 'vector3' then
-            if typeof == 'table' and table.type(coords) ~= 'array' then
-                coords = vec3(coords.x or coords[1], coords.y or coords[2], coords.z or coords[3])
-            else
-                if table.type(coords) == 'array' then
-                    for i = 1, #coords do
-                        coords[i] = vec3(coords[i].x, coords[i].y, coords[i].z)
-                    end
-                else
-                    error(('received %s for stash coords (expected vector3 or array of vector3)'):format(typeof))
-                end
-            end
-        end
-    end
+		if typeof ~= 'vector3' then
+			if typeof == 'table' and table.type(coords) ~= 'array' then
+				coords = vec3(coords.x or coords[1], coords.y or coords[2], coords.z or coords[3])
+			else
+				if table.type(coords) == 'array' then
+					for i = 1, #coords do
+						coords[i] = vec3(coords[i].x, coords[i].y, coords[i].z)
+					end
+				else
+					error(('received %s for stash coords (expected vector3 or array of vector3)'):format(typeof))
+				end
+			end
+		end
+	end
 
-    return name, slots, maxWeight, coords
+	return name, slots, maxWeight, coords
 end
 
 ---@param name string stash identifier when loading from the database
@@ -2700,70 +2700,70 @@ end
 --- groups: { ['police'] = 0 }
 --- ```
 local function registerStash(name, label, slots, maxWeight, owner, groups, coords)
-    name, slots, maxWeight, coords = checkStashProperties({
-        name = name,
-        slots = slots,
-        maxWeight = maxWeight,
-        coords = coords,
-    })
+	name, slots, maxWeight, coords = checkStashProperties({
+		name = name,
+		slots = slots,
+		maxWeight = maxWeight,
+		coords = coords,
+	})
 
-    local curStash = RegisteredStashes[name]
+	local curStash = RegisteredStashes[name]
 
-    if curStash then
-        ---@todo creating proper stash classes with inheritence would simplify updating data
-        ---i.e. all stashes with the same type share groups, maxweight, slots, dbid, etc.
-        ---only label, owner, weight, coords, and items really need to vary
-        for _, stash in pairs(Inventories) do
-            if stash.type == 'stash' and stash.dbId == name then
-                stash.label = label or stash.label
-                stash.owner = (owner and owner ~= true) and stash.owner or owner
-                stash.slots = slots or stash.slots
-                stash.maxWeight = maxWeight or stash.maxWeight
-                stash.groups = groups or stash.groups
-                stash.coords = coords or stash.coords
-            end
-        end
-    end
+	if curStash then
+		---@todo creating proper stash classes with inheritence would simplify updating data
+		---i.e. all stashes with the same type share groups, maxweight, slots, dbid, etc.
+		---only label, owner, weight, coords, and items really need to vary
+		for _, stash in pairs(Inventories) do
+			if stash.type == 'stash' and stash.dbId == name then
+				stash.label = label or stash.label
+				stash.owner = (owner and owner ~= true) and stash.owner or owner
+				stash.slots = slots or stash.slots
+				stash.maxWeight = maxWeight or stash.maxWeight
+				stash.groups = groups or stash.groups
+				stash.coords = coords or stash.coords
+			end
+		end
+	end
 
-    RegisteredStashes[name] = {
-        name = name,
-        label = label,
-        owner = owner,
-        slots = slots,
-        maxWeight = maxWeight,
-        groups = groups,
-        coords = coords
-    }
+	RegisteredStashes[name] = {
+		name = name,
+		label = label,
+		owner = owner,
+		slots = slots,
+		maxWeight = maxWeight,
+		groups = groups,
+		coords = coords
+	}
 end
 
 exports('RegisterStash', registerStash)
 
 ---@param properties TemporaryStashProperties
 function Inventory.CreateTemporaryStash(properties)
-    properties.name = generateInvId('temp')
+	properties.name = generateInvId('temp')
 
-    local name, slots, maxWeight, coords = checkStashProperties(properties)
-    local inventory = Inventory.Create(name, properties.label, 'temp', slots, 0, maxWeight, properties.owner, {},
-        properties.groups)
+	local name, slots, maxWeight, coords = checkStashProperties(properties)
+	local inventory = Inventory.Create(name, properties.label, 'temp', slots, 0, maxWeight, properties.owner, {},
+		properties.groups)
 
-    if not inventory then return end
+	if not inventory then return end
 
-    inventory.items, inventory.weight = generateItems(inventory, 'drop', properties.items)
-    inventory.coords = coords
+	inventory.items, inventory.weight = generateItems(inventory, 'drop', properties.items)
+	inventory.coords = coords
 
-    return inventory.id
+	return inventory.id
 end
 
 exports('CreateTemporaryStash', Inventory.CreateTemporaryStash)
 
 function Inventory.InspectInventory(playerId, invId)
-    local inventory = invId ~= playerId and Inventory(invId)
-    local playerInventory = Inventory(playerId)
+	local inventory = invId ~= playerId and Inventory(invId)
+	local playerInventory = Inventory(playerId)
 
-    if playerInventory and inventory then
-        playerInventory:openInventory(inventory)
-        TriggerClientEvent('ox_inventory:viewInventory', playerId, playerInventory, inventory)
-    end
+	if playerInventory and inventory then
+		playerInventory:openInventory(inventory)
+		TriggerClientEvent('ox_inventory:viewInventory', playerId, playerInventory, inventory)
+	end
 end
 
 exports('InspectInventory', Inventory.InspectInventory)

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -12,39 +12,39 @@ OxInventory.__index = OxInventory
 ---Open a player's inventory, optionally with a secondary inventory.
 ---@param inv? inventory
 function OxInventory:openInventory(inv)
-	if not self?.player then return end
+    if not self?.player then return end
 
-	inv = Inventory(inv)
+    inv = Inventory(inv)
 
-	if not inv then return end
+    if not inv then return end
 
-	inv:set('open', true)
-	inv.openedBy[self.id] = true
-	self.open = inv.id
+    inv:set('open', true)
+    inv.openedBy[self.id] = true
+    self.open = inv.id
 
-	TriggerEvent('ox_inventory:openedInventory', self.id, inv.id)
+    TriggerEvent('ox_inventory:openedInventory', self.id, inv.id)
 end
 
 ---Close a player's inventory.
 ---@param noEvent? boolean
 function OxInventory:closeInventory(noEvent)
-	if not self.player or not self.open then return end
+    if not self.player or not self.open then return end
 
-	local inv = Inventory(self.open)
+    local inv = Inventory(self.open)
 
-	if not inv then return end
+    if not inv then return end
 
-	inv.openedBy[self.id] = nil
-	inv:set('open', false)
-	self.open = false
-	self.currentShop = nil
-	self.containerSlot = nil
+    inv.openedBy[self.id] = nil
+    inv:set('open', false)
+    self.open = false
+    self.currentShop = nil
+    self.containerSlot = nil
 
-	if not noEvent then
-		TriggerClientEvent('ox_inventory:closeInventory', self.id, true)
-	end
+    if not noEvent then
+        TriggerClientEvent('ox_inventory:closeInventory', self.id, true)
+    end
 
-	TriggerEvent('ox_inventory:closedInventory', self.id, inv.id)
+    TriggerEvent('ox_inventory:closedInventory', self.id, inv.id)
 end
 
 ---@alias updateSlot { item: SlotWithItem | { slot: number }, inventory: string|number }
@@ -53,42 +53,42 @@ end
 ---@param slots updateSlot[]
 ---@param weight { left?: number, right?: number } | number
 function OxInventory:syncSlotsWithPlayer(slots, weight)
-	TriggerClientEvent('ox_inventory:updateSlots', self.id, slots, weight)
+    TriggerClientEvent('ox_inventory:updateSlots', self.id, slots, weight)
 end
 
 ---Sync an inventory's state with all player's accessing it.
 ---@param slots updateSlot[]
 ---@param syncOwner? boolean
 function OxInventory:syncSlotsWithClients(slots, syncOwner)
-	for playerId in pairs(self.openedBy) do
-		if self.id ~= playerId then
-			local target = Inventories[playerId]
+    for playerId in pairs(self.openedBy) do
+        if self.id ~= playerId then
+            local target = Inventories[playerId]
 
-			if target then
-				TriggerClientEvent('ox_inventory:updateSlots', playerId, slots, target.weight)
-			end
-		end
-	end
+            if target then
+                TriggerClientEvent('ox_inventory:updateSlots', playerId, slots, target.weight)
+            end
+        end
+    end
 
-	if syncOwner and self.player then
-		TriggerClientEvent('ox_inventory:updateSlots', self.id, slots, self.weight)
-	end
+    if syncOwner and self.player then
+        TriggerClientEvent('ox_inventory:updateSlots', self.id, slots, self.weight)
+    end
 end
 
 local Vehicles = lib.load('data.vehicles')
 local RegisteredStashes = {}
 
 for _, stash in pairs(lib.load('data.stashes') or {}) do
-	RegisteredStashes[stash.name] = {
-		name = stash.name,
-		label = stash.label,
-		owner = stash.owner,
-		slots = stash.slots,
-		maxWeight = stash.weight,
-		groups = stash.groups or stash.jobs,
-		coords = shared.target and stash.target?.loc or stash.coords,
-		distance = stash.distance or 10
-	}
+    RegisteredStashes[stash.name] = {
+        name = stash.name,
+        label = stash.label,
+        owner = stash.owner,
+        slots = stash.slots,
+        maxWeight = stash.weight,
+        groups = stash.groups or stash.jobs,
+        coords = shared.target and stash.target?.loc or stash.coords,
+        distance = stash.distance or 10
+    }
 end
 
 local GetVehicleNumberPlateText = GetVehicleNumberPlateText
@@ -99,132 +99,132 @@ local GetVehicleNumberPlateText = GetVehicleNumberPlateText
 ---@param ignoreSecurityChecks boolean
 ---@return OxInventory | false | nil
 local function loadInventoryData(data, player, ignoreSecurityChecks)
-	local source = source
-	local inventory
+    local source = source
+    local inventory
 
-	if not data.type and type(data.id) == 'string' then
-		if data.id:find('^glove') then
-			data.type = 'glovebox'
-		elseif data.id:find('^trunk') then
-			data.type = 'trunk'
-		elseif data.id:find('^evidence-') then
-			data.type = 'policeevidence'
-		end
-	end
+    if not data.type and type(data.id) == 'string' then
+        if data.id:find('^glove') then
+            data.type = 'glovebox'
+        elseif data.id:find('^trunk') then
+            data.type = 'trunk'
+        elseif data.id:find('^evidence-') then
+            data.type = 'policeevidence'
+        end
+    end
 
-	if data.type == 'trunk' or data.type == 'glovebox' then
-		local plate = data.id:sub(6)
+    if data.type == 'trunk' or data.type == 'glovebox' then
+        local plate = data.id:sub(6)
 
-		if server.trimplate then
-			plate = string.strtrim(plate)
-			data.id = ('%s%s'):format(data.id:sub(1, 5), plate)
-		end
+        if server.trimplate then
+            plate = string.strtrim(plate)
+            data.id = ('%s%s'):format(data.id:sub(1, 5), plate)
+        end
 
-		inventory = Inventories[data.id]
+        inventory = Inventories[data.id]
 
-		if not inventory then
-			local entity
+        if not inventory then
+            local entity
 
-			if data.netid then
-				entity = NetworkGetEntityFromNetworkId(data.netid)
+            if data.netid then
+                entity = NetworkGetEntityFromNetworkId(data.netid)
 
-				if not entity then
-					return shared.info('Failed to load vehicle inventory data (no entity exists with given netid).')
-				end
+                if not entity then
+                    return shared.info('Failed to load vehicle inventory data (no entity exists with given netid).')
+                end
 
-				data.entityId = entity
-			else
-				local vehicles = GetAllVehicles()
+                data.entityId = entity
+            else
+                local vehicles = GetAllVehicles()
 
-				for i = 1, #vehicles do
-					local vehicle = vehicles[i]
-					local _plate = GetVehicleNumberPlateText(vehicle)
+                for i = 1, #vehicles do
+                    local vehicle = vehicles[i]
+                    local _plate = GetVehicleNumberPlateText(vehicle)
 
-					if _plate:find(plate) then
-						entity = vehicle
-						data.entityId = entity
-						data.netid = NetworkGetNetworkIdFromEntity(entity)
-						break
-					end
-				end
+                    if _plate:find(plate) then
+                        entity = vehicle
+                        data.entityId = entity
+                        data.netid = NetworkGetNetworkIdFromEntity(entity)
+                        break
+                    end
+                end
 
-				if not entity then
-					return shared.info('Failed to load vehicle inventory data (no entity exists with given plate).')
-				end
-			end
+                if not entity then
+                    return shared.info('Failed to load vehicle inventory data (no entity exists with given plate).')
+                end
+            end
 
-			if not source then
-				source = NetworkGetEntityOwner(entity)
+            if not source then
+                source = NetworkGetEntityOwner(entity)
 
-				if not source then
-					return shared.info('Failed to load vehicle inventory data (entity is unowned).')
-				end
-			end
+                if not source then
+                    return shared.info('Failed to load vehicle inventory data (entity is unowned).')
+                end
+            end
 
-			local model, class = lib.callback.await('ox_inventory:getVehicleData', source, data.netid)
-			local storage = Vehicles[data.type].models[model] or Vehicles[data.type][class]
-			local dbId
+            local model, class = lib.callback.await('ox_inventory:getVehicleData', source, data.netid)
+            local storage = Vehicles[data.type].models[model] or Vehicles[data.type][class]
+            local dbId
 
-			if server.getOwnedVehicleId then
-				dbId = server.getOwnedVehicleId(entity)
-			else
-				dbId = data.id:sub(6)
-			end
+            if server.getOwnedVehicleId then
+                dbId = server.getOwnedVehicleId(entity)
+            else
+                dbId = data.id:sub(6)
+            end
 
-			inventory = Inventory.Create(data.id, plate, data.type, storage[1], 0, storage[2], false, nil, nil, dbId)
-		end
-	elseif data.type == 'policeevidence' then
-		inventory = Inventory.Create(data.id, locale('police_evidence'), data.type, 100, 0, 100000, false)
-	else
-		local stash = RegisteredStashes[data.id]
+            inventory = Inventory.Create(data.id, plate, data.type, storage[1], 0, storage[2], false, nil, nil, dbId)
+        end
+    elseif data.type == 'policeevidence' then
+        inventory = Inventory.Create(data.id, locale('police_evidence'), data.type, 100, 0, 100000, false)
+    else
+        local stash = RegisteredStashes[data.id]
 
-		if stash then
-			if stash.jobs then stash.groups = stash.jobs end
-			if not ignoreSecurityChecks and player and stash.groups and not server.hasGroup(player, stash.groups) then return end
+        if stash then
+            if stash.jobs then stash.groups = stash.jobs end
+            if not ignoreSecurityChecks and player and stash.groups and not server.hasGroup(player, stash.groups) then return end
 
-			local owner
+            local owner
 
-			if stash.owner then
-				if stash.owner == true then
-					owner = data.owner or player?.owner
-				else
-					owner = stash.owner
-				end
-			end
+            if stash.owner then
+                if stash.owner == true then
+                    owner = data.owner or player?.owner
+                else
+                    owner = stash.owner
+                end
+            end
 
-			inventory = Inventories[owner and ('%s:%s'):format(stash.name, owner) or stash.name]
+            inventory = Inventories[owner and ('%s:%s'):format(stash.name, owner) or stash.name]
 
-			if not inventory then
-				inventory = Inventory.Create(stash.name, stash.label or stash.name, 'stash', stash.slots, 0,
-					stash.maxWeight, owner, nil, stash.groups)
-				inventory.coords = stash.coords
-				inventory.distance = stash.distance
-			end
-		end
-	end
+            if not inventory then
+                inventory = Inventory.Create(stash.name, stash.label or stash.name, 'stash', stash.slots, 0,
+                    stash.maxWeight, owner, nil, stash.groups)
+                inventory.coords = stash.coords
+                inventory.distance = stash.distance
+            end
+        end
+    end
 
-	if data.netid then
-		inventory.entityId = data.entityId or NetworkGetEntityFromNetworkId(data.netid)
-		inventory.netid = data.netid
-	end
+    if data.netid then
+        inventory.entityId = data.entityId or NetworkGetEntityFromNetworkId(data.netid)
+        inventory.netid = data.netid
+    end
 
-	return inventory or false
+    return inventory or false
 end
 
 setmetatable(Inventory, {
-	__call = function(self, inv, player, ignoreSecurityChecks)
-		if Inventory.Lock then return false end
+    __call = function(self, inv, player, ignoreSecurityChecks)
+        if Inventory.Lock then return false end
 
-		if not inv then
-			return self
-		elseif type(inv) == 'table' then
-			if inv.__index then return inv end
+        if not inv then
+            return self
+        elseif type(inv) == 'table' then
+            if inv.__index then return inv end
 
-			return not inv.owner and Inventories[inv.id] or loadInventoryData(inv, player, ignoreSecurityChecks)
-		end
+            return not inv.owner and Inventories[inv.id] or loadInventoryData(inv, player, ignoreSecurityChecks)
+        end
 
-		return Inventories[inv] or loadInventoryData({ id = inv }, player, ignoreSecurityChecks)
-	end
+        return Inventories[inv] or loadInventoryData({ id = inv }, player, ignoreSecurityChecks)
+    end
 })
 
 ---@cast Inventory +fun(inv: inventory, player?: inventory, ignoreSecurityChecks?: boolean): OxInventory|false|nil
@@ -232,15 +232,15 @@ setmetatable(Inventory, {
 ---@param inv inventory
 ---@param owner? string | number
 local function getInventory(inv, owner)
-	if not inv then return Inventory end
+    if not inv then return Inventory end
 
-	local type = type(inv)
+    local type = type(inv)
 
-	if type == 'table' or type == 'number' then
-		return Inventory(inv)
-	else
-		return Inventory({ id = inv, owner = owner })
-	end
+    if type == 'table' or type == 'number' then
+        return Inventory(inv)
+    else
+        return Inventory({ id = inv, owner = owner })
+    end
 end
 
 exports('Inventory', getInventory)
@@ -250,26 +250,26 @@ exports('GetInventory', getInventory)
 ---@param owner? string | number
 ---@return table?
 exports('GetInventoryItems', function(inv, owner)
-	return getInventory(inv, owner)?.items
+    return getInventory(inv, owner)?.items
 end)
 
 ---@param inv inventory
 ---@param slotId number
 ---@return OxInventory?
 function Inventory.GetContainerFromSlot(inv, slotId)
-	local inventory = Inventory(inv)
-	local slotData = inventory and inventory.items[slotId]
+    local inventory = Inventory(inv)
+    local slotData = inventory and inventory.items[slotId]
 
-	if not slotData then return end
+    if not slotData then return end
 
-	local container = Inventory(slotData.metadata.container)
+    local container = Inventory(slotData.metadata.container)
 
-	if not container then
-		container = Inventory.Create(slotData.metadata.container, slotData.label, 'container', slotData.metadata.size[1],
-			0, slotData.metadata.size[2], false)
-	end
+    if not container then
+        container = Inventory.Create(slotData.metadata.container, slotData.label, 'container', slotData.metadata.size[1],
+            0, slotData.metadata.size[2], false)
+    end
 
-	return container
+    return container
 end
 
 exports('GetContainerFromSlot', Inventory.GetContainerFromSlot)
@@ -277,71 +277,71 @@ exports('GetContainerFromSlot', Inventory.GetContainerFromSlot)
 ---@param inv? inventory
 ---@param ignoreId? number|false
 function Inventory.CloseAll(inv, ignoreId)
-	if not inv then
-		for _, data in pairs(Inventories) do
-			for playerId in pairs(data.openedBy) do
-				local playerInv = Inventory(playerId)
+    if not inv then
+        for _, data in pairs(Inventories) do
+            for playerId in pairs(data.openedBy) do
+                local playerInv = Inventory(playerId)
 
-				if playerInv then playerInv:closeInventory(true) end
-			end
-		end
+                if playerInv then playerInv:closeInventory(true) end
+            end
+        end
 
-		return TriggerClientEvent('ox_inventory:closeInventory', -1, true)
-	end
+        return TriggerClientEvent('ox_inventory:closeInventory', -1, true)
+    end
 
-	inv = Inventory(inv) --[[@as OxInventory?]]
+    inv = Inventory(inv) --[[@as OxInventory?]]
 
-	if not inv then return end
+    if not inv then return end
 
-	for playerId in pairs(inv.openedBy) do
-		local playerInv = Inventory(playerId)
+    for playerId in pairs(inv.openedBy) do
+        local playerInv = Inventory(playerId)
 
-		if playerInv and playerId ~= ignoreId then
-			playerInv:closeInventory()
-		end
-	end
+        if playerInv and playerId ~= ignoreId then
+            playerInv:closeInventory()
+        end
+    end
 end
 
 ---@param inv inventory
 ---@param k string
 ---@param v any
 function Inventory.Set(inv, k, v)
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if inv then
-		if type(v) == 'number' then
-			v = math.floor(v + 0.5)
-		end
+    if inv then
+        if type(v) == 'number' then
+            v = math.floor(v + 0.5)
+        end
 
-		if k == 'open' and v == false then
-			if inv.type ~= 'player' then
-				if inv.player then
-					inv.type = 'player'
-				elseif inv.type == 'drop' and not next(inv.items) and not next(inv.openedBy) then
-					return Inventory.Remove(inv)
-				else
-					inv.time = os.time()
-				end
-			end
+        if k == 'open' and v == false then
+            if inv.type ~= 'player' then
+                if inv.player then
+                    inv.type = 'player'
+                elseif inv.type == 'drop' and not next(inv.items) and not next(inv.openedBy) then
+                    return Inventory.Remove(inv)
+                else
+                    inv.time = os.time()
+                end
+            end
 
-			if inv.player then
-				inv.containerSlot = nil
-			end
-		elseif k == 'maxWeight' and v < 1000 then
-			v *= 1000
-		end
+            if inv.player then
+                inv.containerSlot = nil
+            end
+        elseif k == 'maxWeight' and v < 1000 then
+            v *= 1000
+        end
 
-		inv[k] = v
-	end
+        inv[k] = v
+    end
 end
 
 ---@param inv inventory
 ---@param key string
 function Inventory.Get(inv, key)
-	inv = Inventory(inv) --[[@as OxInventory]]
-	if inv then
-		return inv[key]
-	end
+    inv = Inventory(inv) --[[@as OxInventory]]
+    if inv then
+        return inv[key]
+    end
 end
 
 ---@class MinimalInventorySlot
@@ -353,20 +353,20 @@ end
 ---@param inv inventory
 ---@return MinimalInventorySlot[] items
 local function minimal(inv)
-	inv = Inventory(inv) --[[@as OxInventory]]
-	local inventory, count = {}, 0
-	for k, v in pairs(inv.items) do
-		if v.name and v.count > 0 then
-			count += 1
-			inventory[count] = {
-				name = v.name,
-				count = v.count,
-				slot = k,
-				metadata = next(v.metadata) and v.metadata or nil
-			}
-		end
-	end
-	return inventory
+    inv = Inventory(inv) --[[@as OxInventory]]
+    local inventory, count = {}, 0
+    for k, v in pairs(inv.items) do
+        if v.name and v.count > 0 then
+            count += 1
+            inventory[count] = {
+                name = v.name,
+                count = v.count,
+                slot = k,
+                metadata = next(v.metadata) and v.metadata or nil
+            }
+        end
+    end
+    return inventory
 end
 
 ---@param inv inventory
@@ -375,196 +375,196 @@ end
 ---@param metadata any
 ---@param slot any
 function Inventory.SetSlot(inv, item, count, metadata, slot)
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if not inv then return end
+    if not inv then return end
 
-	local currentSlot = inv.items[slot]
-	local newCount = currentSlot and currentSlot.count + count or count
-	local newWeight = currentSlot and inv.weight - currentSlot.weight or inv.weight
+    local currentSlot = inv.items[slot]
+    local newCount = currentSlot and currentSlot.count + count or count
+    local newWeight = currentSlot and inv.weight - currentSlot.weight or inv.weight
 
-	if currentSlot and newCount < 1 then
-		TriggerClientEvent('ox_inventory:itemNotify', inv.id, { currentSlot, 'ui_removed', currentSlot.count })
-		currentSlot = nil
-	else
-		currentSlot = {
-			name = item.name,
-			label = item.label,
-			weight = item.weight,
-			slot = slot,
-			count = newCount,
-			description = item.description,
-			metadata = metadata,
-			stack = item.stack,
-			close = item.close
-		}
-		local slotWeight = Inventory.SlotWeight(item, currentSlot)
-		currentSlot.weight = slotWeight
-		newWeight += slotWeight
+    if currentSlot and newCount < 1 then
+        TriggerClientEvent('ox_inventory:itemNotify', inv.id, { currentSlot, 'ui_removed', currentSlot.count })
+        currentSlot = nil
+    else
+        currentSlot = {
+            name = item.name,
+            label = item.label,
+            weight = item.weight,
+            slot = slot,
+            count = newCount,
+            description = item.description,
+            metadata = metadata,
+            stack = item.stack,
+            close = item.close
+        }
+        local slotWeight = Inventory.SlotWeight(item, currentSlot)
+        currentSlot.weight = slotWeight
+        newWeight += slotWeight
 
-		TriggerClientEvent('ox_inventory:itemNotify', inv.id,
-			{ currentSlot, count < 0 and 'ui_removed' or 'ui_added', math.abs(count) })
-	end
+        TriggerClientEvent('ox_inventory:itemNotify', inv.id,
+            { currentSlot, count < 0 and 'ui_removed' or 'ui_added', math.abs(count) })
+    end
 
-	inv.weight = newWeight
-	inv.items[slot] = currentSlot
-	inv.changed = true
+    inv.weight = newWeight
+    inv.items[slot] = currentSlot
+    inv.changed = true
 
-	return currentSlot
+    return currentSlot
 end
 
 local Items = require 'modules.items.server'
 
 CreateThread(function()
-	Inventory.accounts = server.accounts
-	TriggerEvent('ox_inventory:loadInventory', Inventory)
+    Inventory.accounts = server.accounts
+    TriggerEvent('ox_inventory:loadInventory', Inventory)
 end)
 
 function Inventory.GetAccountItemCounts(inv)
-	inv = Inventory(inv)
+    inv = Inventory(inv)
 
-	if not inv then return end
+    if not inv then return end
 
-	local accounts = table.clone(server.accounts)
+    local accounts = table.clone(server.accounts)
 
-	for _, v in pairs(inv.items) do
-		if accounts[v.name] then
-			accounts[v.name] += v.count
-		end
-	end
+    for _, v in pairs(inv.items) do
+        if accounts[v.name] then
+            accounts[v.name] += v.count
+        end
+    end
 
-	return accounts
+    return accounts
 end
 
 ---@param item table
 ---@param slot table
 function Inventory.SlotWeight(item, slot, ignoreCount)
-	local weight = ignoreCount and item.weight or item.weight * (slot.count or 1)
+    local weight = ignoreCount and item.weight or item.weight * (slot.count or 1)
 
-	if not slot.metadata then slot.metadata = {} end
+    if not slot.metadata then slot.metadata = {} end
 
-	if item.ammoname and slot.metadata.ammo then
-		local ammoWeight = Items(item.ammoname)?.weight
+    if item.ammoname and slot.metadata.ammo then
+        local ammoWeight = Items(item.ammoname)?.weight
 
-		if ammoWeight then
-			weight += (ammoWeight * slot.metadata.ammo)
-		end
-	end
+        if ammoWeight then
+            weight += (ammoWeight * slot.metadata.ammo)
+        end
+    end
 
-	if item.hash == `WEAPON_PETROLCAN` then
-		slot.metadata.weight = 15000 * (slot.metadata.ammo / 100)
-	end
+    if item.hash == `WEAPON_PETROLCAN` then
+        slot.metadata.weight = 15000 * (slot.metadata.ammo / 100)
+    end
 
-	if slot.metadata.components then
-		for i = #slot.metadata.components, 1, -1 do
-			local componentWeight = Items(slot.metadata.components[i])?.weight
+    if slot.metadata.components then
+        for i = #slot.metadata.components, 1, -1 do
+            local componentWeight = Items(slot.metadata.components[i])?.weight
 
-			if componentWeight then
-				weight += componentWeight
-			end
-		end
-	end
+            if componentWeight then
+                weight += componentWeight
+            end
+        end
+    end
 
-	if slot.metadata.weight then
-		weight += ignoreCount and slot.metadata.weight or (slot.metadata.weight * (slot.count or 1))
-	end
+    if slot.metadata.weight then
+        weight += ignoreCount and slot.metadata.weight or (slot.metadata.weight * (slot.count or 1))
+    end
 
-	return weight
+    return weight
 end
 
 ---@param items table
 function Inventory.CalculateWeight(items)
-	local weight = 0
-	for _, v in pairs(items) do
-		local item = Items(v.name)
-		if item then
-			weight = weight + Inventory.SlotWeight(item, v)
-		end
-	end
-	return weight
+    local weight = 0
+    for _, v in pairs(items) do
+        local item = Items(v.name)
+        if item then
+            weight = weight + Inventory.SlotWeight(item, v)
+        end
+    end
+    return weight
 end
 
 -- This should be handled by frameworks, but sometimes isn't or is exploitable in some way.
 local activeIdentifiers = {}
 
 local function hasActiveInventory(playerId, owner)
-	local activePlayer = activeIdentifiers[owner]
+    local activePlayer = activeIdentifiers[owner]
 
-	if activePlayer then
-		if activePlayer == playerId then
-			error('attempted to load active player\'s inventory a secondary time', 0)
-		end
+    if activePlayer then
+        if activePlayer == playerId then
+            error('attempted to load active player\'s inventory a secondary time', 0)
+        end
 
-		local inventory = Inventory(activePlayer)
+        local inventory = Inventory(activePlayer)
 
-		if inventory then
-			local endpoint = GetPlayerEndpoint(activePlayer)
+        if inventory then
+            local endpoint = GetPlayerEndpoint(activePlayer)
 
-			if endpoint then
-				DropPlayer(playerId, ("Character identifier '%s' is already active."):format(owner))
+            if endpoint then
+                DropPlayer(playerId, ("Character identifier '%s' is already active."):format(owner))
 
-				-- Supposedly still getting stuck? Print info and hope somebody reports back (lol)
-				print(('kicked player.%s (charid is already in use)'):format(playerId), json.encode({
-					oldId = activePlayer,
-					newId = playerId,
-					charid = owner,
-					endpoint = endpoint,
-					playerName = GetPlayerName(activePlayer),
-					fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
-					license = GetPlayerIdentifierByType(activePlayer, 'license2') or
-						GetPlayerIdentifierByType(activePlayer, 'license'),
-				}, {
-					indent = true,
-					sort_keys = true
-				}))
+                -- Supposedly still getting stuck? Print info and hope somebody reports back (lol)
+                print(('kicked player.%s (charid is already in use)'):format(playerId), json.encode({
+                    oldId = activePlayer,
+                    newId = playerId,
+                    charid = owner,
+                    endpoint = endpoint,
+                    playerName = GetPlayerName(activePlayer),
+                    fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
+                    license = GetPlayerIdentifierByType(activePlayer, 'license2') or
+                        GetPlayerIdentifierByType(activePlayer, 'license'),
+                }, {
+                    indent = true,
+                    sort_keys = true
+                }))
 
-				return true
-			end
+                return true
+            end
 
-			Inventory.CloseAll(inventory)
-			db.savePlayer(owner, json.encode(inventory:minimal()))
-			Inventory.Remove(inventory)
-			Wait(100)
-		end
-	end
+            Inventory.CloseAll(inventory)
+            db.savePlayer(owner, json.encode(inventory:minimal()))
+            Inventory.Remove(inventory)
+            Wait(100)
+        end
+    end
 
-	activeIdentifiers[owner] = playerId
+    activeIdentifiers[owner] = playerId
 end
 
 ---Manually clear an inventory state tied to the given identifier.
 ---Temporary workaround until somebody actually gives me info.
 RegisterCommand('clearActiveIdentifier', function(source, args)
-	---Server console only.
-	if source ~= 0 then return end
+    ---Server console only.
+    if source ~= 0 then return end
 
-	local activePlayer = activeIdentifiers[args[1]] or activeIdentifiers[tonumber(args[1])]
-	local inventory = activePlayer and Inventory(activePlayer)
+    local activePlayer = activeIdentifiers[args[1]] or activeIdentifiers[tonumber(args[1])]
+    local inventory = activePlayer and Inventory(activePlayer)
 
-	if not inventory then return end
+    if not inventory then return end
 
-	local endpoint = GetPlayerEndpoint(activePlayer)
+    local endpoint = GetPlayerEndpoint(activePlayer)
 
-	if endpoint then
-		DropPlayer(activePlayer, 'Kicked')
+    if endpoint then
+        DropPlayer(activePlayer, 'Kicked')
 
-		-- Supposedly still getting stuck? Print info and hope somebody reports back (lol)
-		print(('kicked player.%s (clearActiveIdentifier)'):format(activePlayer), json.encode({
-			oldId = activePlayer,
-			charid = inventory.owner,
-			endpoint = endpoint,
-			playerName = GetPlayerName(activePlayer),
-			fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
-			license = GetPlayerIdentifierByType(activePlayer, 'license2') or
-				GetPlayerIdentifierByType(activePlayer, 'license'),
-		}, {
-			indent = true,
-			sort_keys = true
-		}))
-	end
+        -- Supposedly still getting stuck? Print info and hope somebody reports back (lol)
+        print(('kicked player.%s (clearActiveIdentifier)'):format(activePlayer), json.encode({
+            oldId = activePlayer,
+            charid = inventory.owner,
+            endpoint = endpoint,
+            playerName = GetPlayerName(activePlayer),
+            fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
+            license = GetPlayerIdentifierByType(activePlayer, 'license2') or
+                GetPlayerIdentifierByType(activePlayer, 'license'),
+        }, {
+            indent = true,
+            sort_keys = true
+        }))
+    end
 
-	Inventory.CloseAll(inventory)
-	db.savePlayer(inventory.owner, json.encode(inventory:minimal()))
-	Inventory.Remove(inventory)
+    Inventory.CloseAll(inventory)
+    db.savePlayer(inventory.owner, json.encode(inventory:minimal()))
+    Inventory.Remove(inventory)
 end, true)
 
 ---@param id string|number
@@ -580,79 +580,79 @@ end, true)
 --- This should only be utilised internally!
 --- To create a stash, please use `exports.ox_inventory:RegisterStash` instead.
 function Inventory.Create(id, label, invType, slots, weight, maxWeight, owner, items, groups, dbId)
-	if invType == 'player' and hasActiveInventory(id, owner) then return end
+    if invType == 'player' and hasActiveInventory(id, owner) then return end
 
-	local self = {
-		id = id,
-		label = label or id,
-		type = invType,
-		slots = slots,
-		weight = weight,
-		maxWeight = maxWeight or shared.playerweight,
-		owner = owner,
-		items = type(items) == 'table' and items,
-		open = false,
-		set = Inventory.Set,
-		get = Inventory.Get,
-		minimal = minimal,
-		time = os.time(),
-		groups = groups,
-		openedBy = {},
-		dbId = dbId
-	}
+    local self = {
+        id = id,
+        label = label or id,
+        type = invType,
+        slots = slots,
+        weight = weight,
+        maxWeight = maxWeight or shared.playerweight,
+        owner = owner,
+        items = type(items) == 'table' and items,
+        open = false,
+        set = Inventory.Set,
+        get = Inventory.Get,
+        minimal = minimal,
+        time = os.time(),
+        groups = groups,
+        openedBy = {},
+        dbId = dbId
+    }
 
-	if invType == 'drop' or invType == 'temp' or invType == 'dumpster' then
-		self.datastore = true
-	else
-		self.changed = false
+    if invType == 'drop' or invType == 'temp' or invType == 'dumpster' then
+        self.datastore = true
+    else
+        self.changed = false
 
-		if invType ~= 'glovebox' and invType ~= 'trunk' then
-			self.dbId = id
+        if invType ~= 'glovebox' and invType ~= 'trunk' then
+            self.dbId = id
 
-			if invType ~= 'player' and owner and type(owner) ~= 'boolean' then
-				self.id = ('%s:%s'):format(self.id, owner)
-			end
-		end
-	end
+            if invType ~= 'player' and owner and type(owner) ~= 'boolean' then
+                self.id = ('%s:%s'):format(self.id, owner)
+            end
+        end
+    end
 
-	if not items then
-		self.items, self.weight = Inventory.Load(self.dbId, invType, owner)
-	elseif weight == 0 and next(items) then
-		self.weight = Inventory.CalculateWeight(items)
-	end
+    if not items then
+        self.items, self.weight = Inventory.Load(self.dbId, invType, owner)
+    elseif weight == 0 and next(items) then
+        self.weight = Inventory.CalculateWeight(items)
+    end
 
-	Inventories[self.id] = setmetatable(self, OxInventory)
-	return Inventories[self.id]
+    Inventories[self.id] = setmetatable(self, OxInventory)
+    return Inventories[self.id]
 end
 
 ---@param inv inventory
 function Inventory.Remove(inv)
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if not inv then return end
+    if not inv then return end
 
-	if inv.type == 'drop' then
-		TriggerClientEvent('ox_inventory:removeDrop', -1, inv.id)
-		Inventory.Drops[inv.id] = nil
-	elseif inv.player then
-		activeIdentifiers[inv.owner] = nil
-	end
+    if inv.type == 'drop' then
+        TriggerClientEvent('ox_inventory:removeDrop', -1, inv.id)
+        Inventory.Drops[inv.id] = nil
+    elseif inv.player then
+        activeIdentifiers[inv.owner] = nil
+    end
 
-	for playerId in pairs(inv.openedBy) do
-		if inv.id ~= playerId then
-			local target = Inventories[playerId]
+    for playerId in pairs(inv.openedBy) do
+        if inv.id ~= playerId then
+            local target = Inventories[playerId]
 
-			if target then
-				target:closeInventory()
-			end
-		end
-	end
+            if target then
+                target:closeInventory()
+            end
+        end
+    end
 
-	if not inv.datastore and inv.changed then
-		Inventory.Save(inv)
-	end
+    if not inv.datastore and inv.changed then
+        Inventory.Save(inv)
+    end
 
-	Inventories[inv.id] = nil
+    Inventories[inv.id] = nil
 end
 
 exports('RemoveInventory', Inventory.Remove)
@@ -661,71 +661,71 @@ exports('RemoveInventory', Inventory.Remove)
 ---@param oldPlate string
 ---@param newPlate string
 function Inventory.UpdateVehicle(oldPlate, newPlate)
-	oldPlate = oldPlate:upper()
-	newPlate = newPlate:upper()
+    oldPlate = oldPlate:upper()
+    newPlate = newPlate:upper()
 
-	if server.trimplate then
-		oldPlate = string.strtrim(oldPlate)
-		newPlate = string.strtrim(newPlate)
-	end
+    if server.trimplate then
+        oldPlate = string.strtrim(oldPlate)
+        newPlate = string.strtrim(newPlate)
+    end
 
-	local trunk = Inventory(('trunk%s'):format(oldPlate))
-	local glove = Inventory(('glove%s'):format(oldPlate))
+    local trunk = Inventory(('trunk%s'):format(oldPlate))
+    local glove = Inventory(('glove%s'):format(oldPlate))
 
-	if trunk then
-		Inventory.CloseAll(trunk)
+    if trunk then
+        Inventory.CloseAll(trunk)
 
-		Inventories[trunk.id] = nil
-		trunk.label = newPlate
-		trunk.dbId = type(trunk.id) == 'number' and trunk.dbId or newPlate
-		trunk.id = ('trunk%s'):format(newPlate)
-		Inventories[trunk.id] = trunk
-	end
+        Inventories[trunk.id] = nil
+        trunk.label = newPlate
+        trunk.dbId = type(trunk.id) == 'number' and trunk.dbId or newPlate
+        trunk.id = ('trunk%s'):format(newPlate)
+        Inventories[trunk.id] = trunk
+    end
 
-	if glove then
-		Inventory.CloseAll(glove)
+    if glove then
+        Inventory.CloseAll(glove)
 
-		Inventories[glove.id] = nil
-		glove.label = newPlate
-		glove.dbId = type(glove.id) == 'number' and glove.dbId or newPlate
-		glove.id = ('glove%s'):format(newPlate)
-		Inventories[glove.id] = glove
-	end
+        Inventories[glove.id] = nil
+        glove.label = newPlate
+        glove.dbId = type(glove.id) == 'number' and glove.dbId or newPlate
+        glove.id = ('glove%s'):format(newPlate)
+        Inventories[glove.id] = glove
+    end
 end
 
 exports('UpdateVehicle', Inventory.UpdateVehicle)
 
 function Inventory.Save(inv)
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if not inv or inv.datastore then return end
+    if not inv or inv.datastore then return end
 
-	local buffer, n = {}, 0
+    local buffer, n = {}, 0
 
-	for k, v in pairs(inv.items) do
-		if not Items.UpdateDurability(inv, v, Items(v.name), nil, os.time()) then
-			n += 1
-			buffer[n] = {
-				name = v.name,
-				count = v.count,
-				slot = k,
-				metadata = next(v.metadata) and v.metadata or nil
-			}
-		end
-	end
+    for k, v in pairs(inv.items) do
+        if not Items.UpdateDurability(inv, v, Items(v.name), nil, os.time()) then
+            n += 1
+            buffer[n] = {
+                name = v.name,
+                count = v.count,
+                slot = k,
+                metadata = next(v.metadata) and v.metadata or nil
+            }
+        end
+    end
 
-	local data = next(buffer) and json.encode(buffer) or nil
-	inv.changed = false
+    local data = next(buffer) and json.encode(buffer) or nil
+    inv.changed = false
 
-	if inv.player then
-		return shared.framework ~= 'esx' and db.savePlayer(inv.owner, data)
-	elseif inv.type == 'trunk' then
-		return db.saveTrunk(inv.dbId, data)
-	elseif inv.type == 'glovebox' then
-		return db.saveGlovebox(inv.dbId, data)
-	end
+    if inv.player then
+        return shared.framework ~= 'esx' and db.savePlayer(inv.owner, data)
+    elseif inv.type == 'trunk' then
+        return db.saveTrunk(inv.dbId, data)
+    elseif inv.type == 'glovebox' then
+        return db.saveGlovebox(inv.dbId, data)
+    end
 
-	return db.saveStash(inv.owner, inv.dbId, data)
+    return db.saveStash(inv.owner, inv.dbId, data)
 end
 
 ---@alias RandomLoot { [1]: string, [2]: number, [3]: number, [4]?: number }
@@ -735,51 +735,51 @@ end
 ---@param size number
 ---@return RandomLoot
 local function randomItem(loot, items, size)
-	local itemIndex = math.random(1, size)
-	local selectedItem = nil
+    local itemIndex = math.random(1, size)
+    local selectedItem = nil
 
-	for _ = 1, size do
-		selectedItem = loot[itemIndex]
-		local found = false
+    for _ = 1, size do
+        selectedItem = loot[itemIndex]
+        local found = false
 
-		for i = 1, #items do
-			if items[i][1] == selectedItem[1] then
-				found = true
-				break
-			end
-		end
+        for i = 1, #items do
+            if items[i][1] == selectedItem[1] then
+                found = true
+                break
+            end
+        end
 
-		if not found then break end
+        if not found then break end
 
-		itemIndex = ((itemIndex - 1) % size) + 1
-	end
+        itemIndex = ((itemIndex - 1) % size) + 1
+    end
 
-	return selectedItem
+    return selectedItem
 end
 
 ---@param loot RandomLoot[]
 ---@return RandomLoot[]
 local function randomLoot(loot)
-	---@type RandomLoot[]
-	local items = {}
-	local size = #loot
-	local itemCount = math.random(0, 3)
+    ---@type RandomLoot[]
+    local items = {}
+    local size = #loot
+    local itemCount = math.random(0, 3)
 
-	for _ = 1, itemCount do
-		if #items >= size then break end
+    for _ = 1, itemCount do
+        if #items >= size then break end
 
-		local item = randomItem(loot, items, size)
+        local item = randomItem(loot, items, size)
 
-		if item and math.random(1, 100) <= (item[4] or 80) then
-			local count = math.random(item[2], item[3])
+        if item and math.random(1, 100) <= (item[4] or 80) then
+            local count = math.random(item[2], item[3])
 
-			if count > 0 then
-				items[#items + 1] = { item[1], count }
-			end
-		end
-	end
+            if count > 0 then
+                items[#items + 1] = { item[1], count }
+            end
+        end
+    end
 
-	return items
+    return items
 end
 
 ---@param inv inventory
@@ -787,112 +787,112 @@ end
 ---@param items? table
 ---@return table returnData, number totalWeight
 local function generateItems(inv, invType, items)
-	if items == nil then
-		if invType == 'dumpster' then
-			items = randomLoot(server.dumpsterloot)
-		elseif invType == 'vehicle' then
-			items = randomLoot(server.vehicleloot)
-		end
-	end
+    if items == nil then
+        if invType == 'dumpster' then
+            items = randomLoot(server.dumpsterloot)
+        elseif invType == 'vehicle' then
+            items = randomLoot(server.vehicleloot)
+        end
+    end
 
-	if not items then
-		items = {}
-	end
+    if not items then
+        items = {}
+    end
 
-	local returnData, totalWeight = table.create(#items, 0), 0
-	for i = 1, #items do
-		local v = items[i]
-		local item = Items(v[1])
-		if not item then
-			warn('unable to generate', v[1], 'item does not exist')
-		else
-			local metadata, count = Items.Metadata(inv, item, v[3] or {}, v[2])
-			local weight = Inventory.SlotWeight(item, { count = count, metadata = metadata })
-			totalWeight = totalWeight + weight
-			returnData[i] = {
-				name = item.name,
-				label = item.label,
-				weight = weight,
-				slot = i,
-				count = count,
-				description =
-					item.description,
-				metadata = metadata,
-				stack = item.stack,
-				close = item.close
-			}
-		end
-	end
+    local returnData, totalWeight = table.create(#items, 0), 0
+    for i = 1, #items do
+        local v = items[i]
+        local item = Items(v[1])
+        if not item then
+            warn('unable to generate', v[1], 'item does not exist')
+        else
+            local metadata, count = Items.Metadata(inv, item, v[3] or {}, v[2])
+            local weight = Inventory.SlotWeight(item, { count = count, metadata = metadata })
+            totalWeight = totalWeight + weight
+            returnData[i] = {
+                name = item.name,
+                label = item.label,
+                weight = weight,
+                slot = i,
+                count = count,
+                description =
+                    item.description,
+                metadata = metadata,
+                stack = item.stack,
+                close = item.close
+            }
+        end
+    end
 
-	return returnData, totalWeight
+    return returnData, totalWeight
 end
 
 ---@param id string|number
 ---@param invType string
 ---@param owner string | number | boolean
 function Inventory.Load(id, invType, owner)
-	if not invType then return end
+    if not invType then return end
 
-	local result
+    local result
 
-	if invType == 'trunk' or invType == 'glovebox' then
-		result = id and (invType == 'trunk' and db.loadTrunk(id) or db.loadGlovebox(id))
+    if invType == 'trunk' or invType == 'glovebox' then
+        result = id and (invType == 'trunk' and db.loadTrunk(id) or db.loadGlovebox(id))
 
-		if not result then
-			if server.randomloot then
-				return generateItems(id, 'vehicle')
-			end
-		else
-			result = result[invType]
-		end
-	elseif invType == 'dumpster' then
-		if server.randomloot then
-			return generateItems(id, invType)
-		end
-	elseif id then
-		result = db.loadStash(owner or '', id)
-	end
+        if not result then
+            if server.randomloot then
+                return generateItems(id, 'vehicle')
+            end
+        else
+            result = result[invType]
+        end
+    elseif invType == 'dumpster' then
+        if server.randomloot then
+            return generateItems(id, invType)
+        end
+    elseif id then
+        result = db.loadStash(owner or '', id)
+    end
 
-	local returnData, weight = {}, 0
+    local returnData, weight = {}, 0
 
-	if result and type(result) == 'string' then
-		result = json.decode(result)
-	end
+    if result and type(result) == 'string' then
+        result = json.decode(result)
+    end
 
-	if result then
-		local ostime = os.time()
+    if result then
+        local ostime = os.time()
 
-		for _, v in pairs(result) do
-			local item = Items(v.name)
-			if item then
-				v.metadata = Items.CheckMetadata(v.metadata or {}, item, v.name, ostime)
-				local slotWeight = Inventory.SlotWeight(item, v)
-				weight += slotWeight
-				returnData[v.slot] = {
-					name = item.name,
-					label = item.label,
-					weight = slotWeight,
-					slot = v.slot,
-					count =
-						v.count,
-					description = item.description,
-					metadata = v.metadata,
-					stack = item.stack,
-					close = item.close
-				}
-			end
-		end
-	end
+        for _, v in pairs(result) do
+            local item = Items(v.name)
+            if item then
+                v.metadata = Items.CheckMetadata(v.metadata or {}, item, v.name, ostime)
+                local slotWeight = Inventory.SlotWeight(item, v)
+                weight += slotWeight
+                returnData[v.slot] = {
+                    name = item.name,
+                    label = item.label,
+                    weight = slotWeight,
+                    slot = v.slot,
+                    count =
+                        v.count,
+                    description = item.description,
+                    metadata = v.metadata,
+                    stack = item.stack,
+                    close = item.close
+                }
+            end
+        end
+    end
 
-	return returnData, weight
+    return returnData, weight
 end
 
 local function assertMetadata(metadata)
-	if metadata and type(metadata) ~= 'table' then
-		metadata = metadata and { type = metadata or nil }
-	end
+    if metadata and type(metadata) ~= 'table' then
+        metadata = metadata and { type = metadata or nil }
+    end
 
-	return metadata
+    return metadata
 end
 
 ---@param inv inventory
@@ -901,31 +901,31 @@ end
 ---@param returnsCount? boolean
 ---@return table | number | nil
 function Inventory.GetItem(inv, item, metadata, returnsCount)
-	if type(item) ~= 'table' then item = Items(item) end
+    if type(item) ~= 'table' then item = Items(item) end
 
-	if item then
-		item = returnsCount and item or table.clone(item)
-		inv = Inventory(inv) --[[@as OxInventory]]
-		local count = 0
+    if item then
+        item = returnsCount and item or table.clone(item)
+        inv = Inventory(inv) --[[@as OxInventory]]
+        local count = 0
 
-		if inv then
-			local ostime = os.time()
-			metadata = assertMetadata(metadata)
+        if inv then
+            local ostime = os.time()
+            metadata = assertMetadata(metadata)
 
-			for _, v in pairs(inv.items) do
-				if v.name == item.name and (not metadata or table.contains(v.metadata, metadata)) and not Items.UpdateDurability(inv, v, item, nil, ostime) then
-					count += v.count
-				end
-			end
-		end
+            for _, v in pairs(inv.items) do
+                if v.name == item.name and (not metadata or table.contains(v.metadata, metadata)) and not Items.UpdateDurability(inv, v, item, nil, ostime) then
+                    count += v.count
+                end
+            end
+        end
 
-		if returnsCount then
-			return count
-		else
-			item.count = count
-			return item
-		end
-	end
+        if returnsCount then
+            return count
+        else
+            item.count = count
+            return item
+        end
+    end
 end
 
 exports('GetItem', Inventory.GetItem)
@@ -935,26 +935,26 @@ exports('GetItem', Inventory.GetItem)
 ---@param slot1 number
 ---@param slot2 number
 function Inventory.SwapSlots(fromInventory, toInventory, slot1, slot2)
-	local fromSlot = fromInventory.items[slot1] and table.clone(fromInventory.items[slot1]) or nil
-	local toSlot = toInventory.items[slot2] and table.clone(toInventory.items[slot2]) or nil
+    local fromSlot = fromInventory.items[slot1] and table.clone(fromInventory.items[slot1]) or nil
+    local toSlot = toInventory.items[slot2] and table.clone(toInventory.items[slot2]) or nil
 
-	if fromSlot then fromSlot.slot = slot2 end
-	if toSlot then toSlot.slot = slot1 end
+    if fromSlot then fromSlot.slot = slot2 end
+    if toSlot then toSlot.slot = slot1 end
 
-	fromInventory.items[slot1], toInventory.items[slot2] = toSlot, fromSlot
-	fromInventory.changed, toInventory.changed = true, true
+    fromInventory.items[slot1], toInventory.items[slot2] = toSlot, fromSlot
+    fromInventory.changed, toInventory.changed = true, true
 
-	return fromSlot, toSlot
+    return fromSlot, toSlot
 end
 
 exports('SwapSlots', Inventory.SwapSlots)
 
 function Inventory.ContainerWeight(container, metaWeight, playerInventory)
-	playerInventory.weight -= container.weight
-	container.weight = Items(container.name).weight
-	container.weight += metaWeight
-	container.metadata.weight = metaWeight
-	playerInventory.weight += container.weight
+    playerInventory.weight -= container.weight
+    container.weight = Items(container.name).weight
+    container.weight += metaWeight
+    container.metadata.weight = metaWeight
+    playerInventory.weight += container.weight
 end
 
 ---@param inv inventory
@@ -963,45 +963,45 @@ end
 ---@param metadata? table
 ---@return boolean? success, string|SlotWithItem|nil response
 function Inventory.SetItem(inv, item, count, metadata)
-	if type(item) ~= 'table' then item = Items(item) end
+    if type(item) ~= 'table' then item = Items(item) end
 
-	if not item then return false, 'invalid_item' end
-	if type(count) ~= 'number' then return false, 'invalid_count' end
+    if not item then return false, 'invalid_item' end
+    if type(count) ~= 'number' then return false, 'invalid_count' end
 
-	count = math.floor(count + 0.5)
-	if count < 0 then return false, 'negative_count' end
+    count = math.floor(count + 0.5)
+    if count < 0 then return false, 'negative_count' end
 
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if not inv then return false, 'invalid_inventory' end
+    if not inv then return false, 'invalid_inventory' end
 
-	inv.changed = true
-	local itemCount = Inventory.GetItem(inv, item.name, metadata, true) --[[@as number]]
+    inv.changed = true
+    local itemCount = Inventory.GetItem(inv, item.name, metadata, true) --[[@as number]]
 
-	if count > itemCount then
-		count -= itemCount
-		return Inventory.AddItem(inv, item.name, count, metadata)
-	elseif count < itemCount then
-		itemCount -= count
-		return Inventory.RemoveItem(inv, item.name, itemCount, metadata)
-	end
+    if count > itemCount then
+        count -= itemCount
+        return Inventory.AddItem(inv, item.name, count, metadata)
+    elseif count < itemCount then
+        itemCount -= count
+        return Inventory.RemoveItem(inv, item.name, itemCount, metadata)
+    end
 end
 
 exports('SetItem', Inventory.SetItem)
 
 ---@param inv inventory
 function Inventory.GetCurrentWeapon(inv)
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if inv?.player then
-		local weapon = inv.items[inv.weapon]
+    if inv?.player then
+        local weapon = inv.items[inv.weapon]
 
-		if weapon and Items(weapon.name).weapon then
-			return weapon
-		end
+        if weapon and Items(weapon.name).weapon then
+            return weapon
+        end
 
-		inv.weapon = nil
-	end
+        inv.weapon = nil
+    end
 end
 
 exports('GetCurrentWeapon', Inventory.GetCurrentWeapon)
@@ -1010,14 +1010,14 @@ exports('GetCurrentWeapon', Inventory.GetCurrentWeapon)
 ---@param slotId number
 ---@return table? item
 function Inventory.GetSlot(inv, slotId)
-	if not inv or type(slotId) ~= 'number' then return end
+    if not inv or type(slotId) ~= 'number' then return end
 
-	inv = Inventory(inv) --[[@as OxInventory]]
-	local slot = inv and inv.items?[slotId]
+    inv = Inventory(inv) --[[@as OxInventory]]
+    local slot = inv and inv.items?[slotId]
 
-	if slot and not Items.UpdateDurability(inv, slot, Items(slot.name), nil, os.time()) then
-		return slot
-	end
+    if slot and not Items.UpdateDurability(inv, slot, Items(slot.name), nil, os.time()) then
+        return slot
+    end
 end
 
 exports('GetSlot', Inventory.GetSlot)
@@ -1026,18 +1026,18 @@ exports('GetSlot', Inventory.GetSlot)
 ---@param slotId number
 ---@param durability number
 function Inventory.SetDurability(inv, slotId, durability)
-	if not inv or type(slotId) ~= 'number' or type(durability) ~= 'number' then return end
+    if not inv or type(slotId) ~= 'number' or type(durability) ~= 'number' then return end
 
-	inv = Inventory(inv) --[[@as OxInventory]]
-	local slot = inv and inv.items?[slotId]
+    inv = Inventory(inv) --[[@as OxInventory]]
+    local slot = inv and inv.items?[slotId]
 
-	if not slot then return end
+    if not slot then return end
 
-	Items.UpdateDurability(inv, slot, Items(slot.name), durability)
+    Items.UpdateDurability(inv, slot, Items(slot.name), durability)
 
-	if inv.player and server.syncInventory then
-		server.syncInventory(inv)
-	end
+    if inv.player and server.syncInventory then
+        server.syncInventory(inv)
+    end
 end
 
 exports('SetDurability', Inventory.SetDurability)
@@ -1048,53 +1048,53 @@ local Utils = require 'modules.utils.server'
 ---@param slotId number
 ---@param metadata { [string]: any }
 function Inventory.SetMetadata(inv, slotId, metadata)
-	if not inv or type(slotId) ~= 'number' then return end
+    if not inv or type(slotId) ~= 'number' then return end
 
-	inv = Inventory(inv) --[[@as OxInventory]]
-	local slot = inv and inv.items?[slotId]
+    inv = Inventory(inv) --[[@as OxInventory]]
+    local slot = inv and inv.items?[slotId]
 
-	if not slot then return end
+    if not slot then return end
 
-	local item = Items(slot.name)
-	local imageurl = slot.metadata.imageurl
-	slot.metadata = type(metadata) == 'table' and metadata or { type = metadata or nil }
-	inv.changed = true
+    local item = Items(slot.name)
+    local imageurl = slot.metadata.imageurl
+    slot.metadata = type(metadata) == 'table' and metadata or { type = metadata or nil }
+    inv.changed = true
 
-	if metadata.weight then
-		inv.weight -= slot.weight
-		slot.weight = Inventory.SlotWeight(item, slot)
-		inv.weight += slot.weight
-	end
+    if metadata.weight then
+        inv.weight -= slot.weight
+        slot.weight = Inventory.SlotWeight(item, slot)
+        inv.weight += slot.weight
+    end
 
-	if metadata.durability ~= slot.metadata.durability then
-		Items.UpdateDurability(inv, slot, item, metadata.durability)
-	else
-		inv:syncSlotsWithClients({
-			{
-				item = slot,
-				inventory = inv.id
-			}
-		}, true)
-	end
+    if metadata.durability ~= slot.metadata.durability then
+        Items.UpdateDurability(inv, slot, item, metadata.durability)
+    else
+        inv:syncSlotsWithClients({
+            {
+                item = slot,
+                inventory = inv.id
+            }
+        }, true)
+    end
 
-	if inv.player and server.syncInventory then
-		server.syncInventory(inv)
-	end
+    if inv.player and server.syncInventory then
+        server.syncInventory(inv)
+    end
 
-	if metadata.imageurl ~= imageurl and Utils.IsValidImageUrl then
-		if Utils.IsValidImageUrl(metadata.imageurl) then
-			Utils.DiscordEmbed('Valid image URL',
-				('Updated item "%s" (%s) with valid url in "%s".\n%s\nid: %s\nowner: %s'):format(
-					metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id, inv.owner,
-					metadata.imageurl), metadata.imageurl, 65280)
-		else
-			Utils.DiscordEmbed('Invalid image URL',
-				('Updated item "%s" (%s) with invalid url in "%s".\n%s\nid: %s\nowner: %s'):format(
-					metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id, inv.owner,
-					metadata.imageurl), metadata.imageurl, 16711680)
-			metadata.imageurl = nil
-		end
-	end
+    if metadata.imageurl ~= imageurl and Utils.IsValidImageUrl then
+        if Utils.IsValidImageUrl(metadata.imageurl) then
+            Utils.DiscordEmbed('Valid image URL',
+                ('Updated item "%s" (%s) with valid url in "%s".\n%s\nid: %s\nowner: %s'):format(
+                    metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id, inv.owner,
+                    metadata.imageurl), metadata.imageurl, 65280)
+        else
+            Utils.DiscordEmbed('Invalid image URL',
+                ('Updated item "%s" (%s) with invalid url in "%s".\n%s\nid: %s\nowner: %s'):format(
+                    metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id, inv.owner,
+                    metadata.imageurl), metadata.imageurl, 16711680)
+            metadata.imageurl = nil
+        end
+    end
 end
 
 exports('SetMetadata', Inventory.SetMetadata)
@@ -1102,23 +1102,23 @@ exports('SetMetadata', Inventory.SetMetadata)
 ---@param inv inventory
 ---@param slots number
 function Inventory.SetSlotCount(inv, slots)
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if not inv then return end
-	if type(slots) ~= 'number' then return end
+    if not inv then return end
+    if type(slots) ~= 'number' then return end
 
-	inv.changed = true
-	inv.slots = slots
+    inv.changed = true
+    inv.slots = slots
 
-	if inv.player then
-		TriggerClientEvent('ox_inventory:refreshSlotCount', inv.id, { inventoryId = inv.id, slots = inv.slots })
-	end
+    if inv.player then
+        TriggerClientEvent('ox_inventory:refreshSlotCount', inv.id, { inventoryId = inv.id, slots = inv.slots })
+    end
 
-	for playerId in pairs(inv.openedBy) do
-		if playerId ~= inv.id then
-			TriggerClientEvent('ox_inventory:refreshSlotCount', playerId, { inventoryId = inv.id, slots = inv.slots })
-		end
-	end
+    for playerId in pairs(inv.openedBy) do
+        if playerId ~= inv.id then
+            TriggerClientEvent('ox_inventory:refreshSlotCount', playerId, { inventoryId = inv.id, slots = inv.slots })
+        end
+    end
 end
 
 exports('SetSlotCount', Inventory.SetSlotCount)
@@ -1126,23 +1126,23 @@ exports('SetSlotCount', Inventory.SetSlotCount)
 ---@param inv inventory
 ---@param maxWeight number
 function Inventory.SetMaxWeight(inv, maxWeight)
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if not inv then return end
-	if type(maxWeight) ~= 'number' then return end
+    if not inv then return end
+    if type(maxWeight) ~= 'number' then return end
 
-	inv.maxWeight = maxWeight
+    inv.maxWeight = maxWeight
 
-	if inv.player then
-		TriggerClientEvent('ox_inventory:refreshMaxWeight', inv.id, { inventoryId = inv.id, maxWeight = inv.maxWeight })
-	end
+    if inv.player then
+        TriggerClientEvent('ox_inventory:refreshMaxWeight', inv.id, { inventoryId = inv.id, maxWeight = inv.maxWeight })
+    end
 
-	for playerId in pairs(inv.openedBy) do
-		if playerId ~= inv.id then
-			TriggerClientEvent('ox_inventory:refreshMaxWeight', playerId,
-				{ inventoryId = inv.id, maxWeight = inv.maxWeight })
-		end
-	end
+    for playerId in pairs(inv.openedBy) do
+        if playerId ~= inv.id then
+            TriggerClientEvent('ox_inventory:refreshMaxWeight', playerId,
+                { inventoryId = inv.id, maxWeight = inv.maxWeight })
+        end
+    end
 end
 
 exports('SetMaxWeight', Inventory.SetMaxWeight)
@@ -1155,149 +1155,149 @@ exports('SetMaxWeight', Inventory.SetMaxWeight)
 ---@param cb? fun(success?: boolean, response: string|SlotWithItem|nil)
 ---@return boolean? success, string|SlotWithItem|nil response
 function Inventory.AddItem(inv, item, count, metadata, slot, cb)
-	if type(item) ~= 'table' then item = Items(item) end
+    if type(item) ~= 'table' then item = Items(item) end
 
-	if not item then return false, 'invalid_item' end
-	if type(count) ~= 'number' then return false, 'invalid_count' end
+    if not item then return false, 'invalid_item' end
+    if type(count) ~= 'number' then return false, 'invalid_count' end
 
-	count = math.floor(count + 0.5)
-	if count <= 0 then return false, 'negative_count' end
+    count = math.floor(count + 0.5)
+    if count <= 0 then return false, 'negative_count' end
 
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if not inv?.slots then return false, 'invalid_inventory' end
+    if not inv?.slots then return false, 'invalid_inventory' end
 
-	local toSlot, slotMetadata, slotCount
-	local success, response = false
+    local toSlot, slotMetadata, slotCount
+    local success, response = false
 
-	metadata = assertMetadata(metadata)
+    metadata = assertMetadata(metadata)
 
-	if slot then
-		local slotData = inv.items[slot]
-		slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
+    if slot then
+        local slotData = inv.items[slot]
+        slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
 
-		if not slotData or item.stack == true then
-			toSlot = slot
-		elseif slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
-			if type(item.stack) == "number" then
-				local freeSpace = item.stack - slotData.count
-				if freeSpace > 0 then
-					slotCount = math.min(count, freeSpace)
-					toSlot = slot
-					count = count - slotCount
-				end
-			end
-		end
-	end
+        if not slotData or item.stack == true then
+            toSlot = slot
+        elseif slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
+            if type(item.stack) == "number" then
+                local freeSpace = item.stack - slotData.count
+                if freeSpace > 0 then
+                    slotCount = math.min(count, freeSpace)
+                    toSlot = slot
+                    count = count - slotCount
+                end
+            end
+        end
+    end
 
-	if not toSlot then
-		local items = inv.items
-		slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
+    if not toSlot then
+        local items = inv.items
+        slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
 
-		for i = 1, inv.slots do
-			local slotData = items[i]
+        for i = 1, inv.slots do
+            local slotData = items[i]
 
-			if type(item.stack) == 'number' and slotData ~= nil and slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
-				local freeSpace = item.stack - slotData.count
-				if freeSpace > 0 then
-					if count <= freeSpace then
-						toSlot = i
-						slotCount = count
-						count = 0
-						break
-					else
-						if not toSlot or type(toSlot) ~= 'table' then toSlot = {} end
-						toSlot[#toSlot + 1] = { slot = i, count = freeSpace, metadata = slotMetadata }
-						count -= freeSpace
-					end
-				end
-			elseif item.stack == true and slotData ~= nil and slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
-				toSlot = i
-				break
-			elseif not item.stack and not slotData then
-				if not toSlot then toSlot = {} end
-				toSlot[#toSlot + 1] = { slot = i, count = slotCount, metadata = slotMetadata }
-				if count == slotCount then
-					break
-				end
-				count -= 1
-				slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
-			elseif not slotData then
-				if type(item.stack) == 'number' and count > 0 then
-					if not toSlot or type(toSlot) ~= 'table' then toSlot = {} end
-					local addCount = math.min(count, item.stack)
-					toSlot[#toSlot + 1] = { slot = i, count = addCount, metadata = slotMetadata }
-					count -= addCount
-					if count <= 0 then break end
-				elseif not toSlot then
-					toSlot = i
-				end
-			end
-		end
-	end
+            if type(item.stack) == 'number' and slotData ~= nil and slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
+                local freeSpace = item.stack - slotData.count
+                if freeSpace > 0 then
+                    if count <= freeSpace then
+                        toSlot = i
+                        slotCount = count
+                        count = 0
+                        break
+                    else
+                        if not toSlot or type(toSlot) ~= 'table' then toSlot = {} end
+                        toSlot[#toSlot + 1] = { slot = i, count = freeSpace, metadata = slotMetadata }
+                        count -= freeSpace
+                    end
+                end
+            elseif item.stack == true and slotData ~= nil and slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
+                toSlot = i
+                break
+            elseif not item.stack and not slotData then
+                if not toSlot then toSlot = {} end
+                toSlot[#toSlot + 1] = { slot = i, count = slotCount, metadata = slotMetadata }
+                if count == slotCount then
+                    break
+                end
+                count -= 1
+                slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
+            elseif not slotData then
+                if type(item.stack) == 'number' and count > 0 then
+                    if not toSlot or type(toSlot) ~= 'table' then toSlot = {} end
+                    local addCount = math.min(count, item.stack)
+                    toSlot[#toSlot + 1] = { slot = i, count = addCount, metadata = slotMetadata }
+                    count -= addCount
+                    if count <= 0 then break end
+                elseif not toSlot then
+                    toSlot = i
+                end
+            end
+        end
+    end
 
-	if not toSlot then return false, 'inventory_full' end
+    if not toSlot then return false, 'inventory_full' end
 
-	inv.changed = true
+    inv.changed = true
 
-	local invokingResource = server.loglevel > 1 and GetInvokingResource()
-	local toSlotType = type(toSlot)
+    local invokingResource = server.loglevel > 1 and GetInvokingResource()
+    local toSlotType = type(toSlot)
 
-	if toSlotType == 'number' then
-		Inventory.SetSlot(inv, item, slotCount, slotMetadata, toSlot)
+    if toSlotType == 'number' then
+        Inventory.SetSlot(inv, item, slotCount, slotMetadata, toSlot)
 
-		if inv.player and server.syncInventory then
-			server.syncInventory(inv)
-		end
+        if inv.player and server.syncInventory then
+            server.syncInventory(inv)
+        end
 
-		inv:syncSlotsWithClients({
-			{
-				item = inv.items[toSlot],
-				inventory = inv.id
-			}
-		}, true)
+        inv:syncSlotsWithClients({
+            {
+                item = inv.items[toSlot],
+                inventory = inv.id
+            }
+        }, true)
 
-		if invokingResource then
-			lib.logger(inv.owner, 'addItem',
-				('"%s" added %sx %s to "%s"'):format(invokingResource, count, item.name, inv.label))
-		end
+        if invokingResource then
+            lib.logger(inv.owner, 'addItem',
+                ('"%s" added %sx %s to "%s"'):format(invokingResource, count, item.name, inv.label))
+        end
 
-		success = true
-		response = inv.items[toSlot]
-	elseif toSlotType == 'table' then
-		local added = 0
+        success = true
+        response = inv.items[toSlot]
+    elseif toSlotType == 'table' then
+        local added = 0
 
-		for i = 1, #toSlot do
-			local data = toSlot[i]
-			added += data.count
-			Inventory.SetSlot(inv, item, data.count, data.metadata, data.slot)
-			toSlot[i] = { item = inv.items[data.slot], inventory = inv.id }
-		end
+        for i = 1, #toSlot do
+            local data = toSlot[i]
+            added += data.count
+            Inventory.SetSlot(inv, item, data.count, data.metadata, data.slot)
+            toSlot[i] = { item = inv.items[data.slot], inventory = inv.id }
+        end
 
-		if inv.player and server.syncInventory then
-			server.syncInventory(inv)
-		end
+        if inv.player and server.syncInventory then
+            server.syncInventory(inv)
+        end
 
-		inv:syncSlotsWithClients(toSlot, true)
+        inv:syncSlotsWithClients(toSlot, true)
 
-		if invokingResource then
-			lib.logger(inv.owner, 'addItem',
-				('"%s" added %sx %s to "%s"'):format(invokingResource, added, item.name, inv.label))
-		end
+        if invokingResource then
+            lib.logger(inv.owner, 'addItem',
+                ('"%s" added %sx %s to "%s"'):format(invokingResource, added, item.name, inv.label))
+        end
 
-		for i = 1, #toSlot do
-			toSlot[i] = toSlot[i].item
-		end
+        for i = 1, #toSlot do
+            toSlot[i] = toSlot[i].item
+        end
 
-		success = true
-		response = toSlot
-	end
+        success = true
+        response = toSlot
+    end
 
-	if cb then
-		return cb(success, response)
-	end
+    if cb then
+        return cb(success, response)
+    end
 
-	return success, response
+    return success, response
 end
 
 exports('AddItem', Inventory.AddItem)
@@ -1307,49 +1307,49 @@ exports('AddItem', Inventory.AddItem)
 ---@param items table | string
 ---@param metadata? table | string
 function Inventory.Search(inv, search, items, metadata)
-	if items then
-		inv = Inventory(inv) --[[@as OxInventory]]
+    if items then
+        inv = Inventory(inv) --[[@as OxInventory]]
 
-		if inv then
-			inv = inv.items
+        if inv then
+            inv = inv.items
 
-			if search == 'slots' then search = 1 elseif search == 'count' then search = 2 end
-			if type(items) == 'string' then items = { items } end
+            if search == 'slots' then search = 1 elseif search == 'count' then search = 2 end
+            if type(items) == 'string' then items = { items } end
 
-			metadata = assertMetadata(metadata)
-			local itemCount = #items
-			local returnData = {}
+            metadata = assertMetadata(metadata)
+            local itemCount = #items
+            local returnData = {}
 
-			for i = 1, itemCount do
-				local item = string.lower(items[i])
-				if item:sub(0, 7) == 'weapon_' then item = string.upper(item) end
+            for i = 1, itemCount do
+                local item = string.lower(items[i])
+                if item:sub(0, 7) == 'weapon_' then item = string.upper(item) end
 
-				if search == 1 then
-					returnData[item] = {}
-				elseif search == 2 then
-					returnData[item] = 0
-				end
+                if search == 1 then
+                    returnData[item] = {}
+                elseif search == 2 then
+                    returnData[item] = 0
+                end
 
-				for _, v in pairs(inv) do
-					if v.name == item then
-						if not v.metadata then v.metadata = {} end
+                for _, v in pairs(inv) do
+                    if v.name == item then
+                        if not v.metadata then v.metadata = {} end
 
-						if not metadata or table.contains(v.metadata, metadata) then
-							if search == 1 then
-								returnData[item][#returnData[item] + 1] = inv[v.slot]
-							elseif search == 2 then
-								returnData[item] += v.count
-							end
-						end
-					end
-				end
-			end
+                        if not metadata or table.contains(v.metadata, metadata) then
+                            if search == 1 then
+                                returnData[item][#returnData[item] + 1] = inv[v.slot]
+                            elseif search == 2 then
+                                returnData[item] += v.count
+                            end
+                        end
+                    end
+                end
+            end
 
-			if next(returnData) then return itemCount == 1 and returnData[items[1]] or returnData end
-		end
-	end
+            if next(returnData) then return itemCount == 1 and returnData[items[1]] or returnData end
+        end
+    end
 
-	return false
+    return false
 end
 
 exports('Search', Inventory.Search)
@@ -1359,31 +1359,31 @@ exports('Search', Inventory.Search)
 ---@param metadata? table
 ---@param strict? boolean
 function Inventory.GetItemSlots(inv, item, metadata, strict)
-	if type(item) ~= 'table' then item = Items(item) end
-	if not item then return end
+    if type(item) ~= 'table' then item = Items(item) end
+    if not item then return end
 
-	inv = Inventory(inv) --[[@as OxInventory]]
-	if not inv?.slots then return end
+    inv = Inventory(inv) --[[@as OxInventory]]
+    if not inv?.slots then return end
 
-	local totalCount, slots, emptySlots = 0, {}, inv.slots
+    local totalCount, slots, emptySlots = 0, {}, inv.slots
 
-	if strict == nil then strict = true end
-	local tablematch = strict and table.matches or table.contains
+    if strict == nil then strict = true end
+    local tablematch = strict and table.matches or table.contains
 
-	for k, v in pairs(inv.items) do
-		emptySlots -= 1
-		if v.name == item.name then
-			if metadata and v.metadata == nil then
-				v.metadata = {}
-			end
-			if not metadata or tablematch(v.metadata, metadata) then
-				totalCount = totalCount + v.count
-				slots[k] = v.count
-			end
-		end
-	end
+    for k, v in pairs(inv.items) do
+        emptySlots -= 1
+        if v.name == item.name then
+            if metadata and v.metadata == nil then
+                v.metadata = {}
+            end
+            if not metadata or tablematch(v.metadata, metadata) then
+                totalCount = totalCount + v.count
+                slots[k] = v.count
+            end
+        end
+    end
 
-	return slots, totalCount, emptySlots
+    return slots, totalCount, emptySlots
 end
 
 exports('GetItemSlots', Inventory.GetItemSlots)
@@ -1397,92 +1397,92 @@ exports('GetItemSlots', Inventory.GetItemSlots)
 ---@param strict? boolean
 ---@return boolean? success, string? response
 function Inventory.RemoveItem(inv, item, count, metadata, slot, ignoreTotal, strict)
-	if type(item) ~= 'table' then item = Items(item) end
+    if type(item) ~= 'table' then item = Items(item) end
 
-	if not item then return false, 'invalid_item' end
-	if type(count) ~= 'number' then return false, 'invalid_count' end
+    if not item then return false, 'invalid_item' end
+    if type(count) ~= 'number' then return false, 'invalid_count' end
 
-	count = math.floor(count + 0.5)
-	if count <= 0 then return false, 'negative_count' end
+    count = math.floor(count + 0.5)
+    if count <= 0 then return false, 'negative_count' end
 
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if not inv?.slots then return false, 'invalid_inventory' end
+    if not inv?.slots then return false, 'invalid_inventory' end
 
-	metadata = assertMetadata(metadata)
-	if strict == nil then strict = true end
-	local itemSlots, totalCount = Inventory.GetItemSlots(inv, item, metadata, strict)
+    metadata = assertMetadata(metadata)
+    if strict == nil then strict = true end
+    local itemSlots, totalCount = Inventory.GetItemSlots(inv, item, metadata, strict)
 
-	if not itemSlots then return false end
+    if not itemSlots then return false end
 
-	if totalCount and count > totalCount then
-		if not ignoreTotal then return false, 'not_enough_items' end
+    if totalCount and count > totalCount then
+        if not ignoreTotal then return false, 'not_enough_items' end
 
-		count = totalCount
-	end
+        count = totalCount
+    end
 
-	local removed, total, slots = 0, count, {}
+    local removed, total, slots = 0, count, {}
 
-	if slot and itemSlots[slot] then
-		removed = count
-		Inventory.SetSlot(inv, item, -count, inv.items[slot].metadata, slot)
-		slots[#slots + 1] = inv.items[slot] or slot
-	elseif itemSlots and totalCount > 0 then
-		for k, v in pairs(itemSlots) do
-			if removed < total then
-				if v == count then
-					TriggerClientEvent('ox_inventory:itemNotify', inv.id, { inv.items[k], 'ui_removed', v })
+    if slot and itemSlots[slot] then
+        removed = count
+        Inventory.SetSlot(inv, item, -count, inv.items[slot].metadata, slot)
+        slots[#slots + 1] = inv.items[slot] or slot
+    elseif itemSlots and totalCount > 0 then
+        for k, v in pairs(itemSlots) do
+            if removed < total then
+                if v == count then
+                    TriggerClientEvent('ox_inventory:itemNotify', inv.id, { inv.items[k], 'ui_removed', v })
 
-					removed = total
-					inv.weight -= inv.items[k].weight
-					inv.items[k] = nil
-					slots[#slots + 1] = inv.items[k] or k
-				elseif v > count then
-					Inventory.SetSlot(inv, item, -count, inv.items[k].metadata, k)
-					slots[#slots + 1] = inv.items[k] or k
-					removed = total
-					count = v - count
-				else
-					TriggerClientEvent('ox_inventory:itemNotify', inv.id, { inv.items[k], 'ui_removed', v })
+                    removed = total
+                    inv.weight -= inv.items[k].weight
+                    inv.items[k] = nil
+                    slots[#slots + 1] = inv.items[k] or k
+                elseif v > count then
+                    Inventory.SetSlot(inv, item, -count, inv.items[k].metadata, k)
+                    slots[#slots + 1] = inv.items[k] or k
+                    removed = total
+                    count = v - count
+                else
+                    TriggerClientEvent('ox_inventory:itemNotify', inv.id, { inv.items[k], 'ui_removed', v })
 
-					removed = removed + v
-					count = count - v
-					inv.weight -= inv.items[k].weight
-					inv.items[k] = nil
-					slots[#slots + 1] = k
-				end
-			else
-				break
-			end
-		end
-	end
+                    removed = removed + v
+                    count = count - v
+                    inv.weight -= inv.items[k].weight
+                    inv.items[k] = nil
+                    slots[#slots + 1] = k
+                end
+            else
+                break
+            end
+        end
+    end
 
-	if removed > 0 then
-		inv.changed = true
+    if removed > 0 then
+        inv.changed = true
 
-		if inv.player and server.syncInventory then
-			server.syncInventory(inv)
-		end
+        if inv.player and server.syncInventory then
+            server.syncInventory(inv)
+        end
 
-		local array = table.create(#slots, 0)
+        local array = table.create(#slots, 0)
 
-		for k, v in pairs(slots) do
-			array[k] = { item = type(v) == 'number' and { slot = v } or v, inventory = inv.id }
-		end
+        for k, v in pairs(slots) do
+            array[k] = { item = type(v) == 'number' and { slot = v } or v, inventory = inv.id }
+        end
 
-		inv:syncSlotsWithClients(array, true)
+        inv:syncSlotsWithClients(array, true)
 
-		local invokingResource = server.loglevel > 1 and GetInvokingResource()
+        local invokingResource = server.loglevel > 1 and GetInvokingResource()
 
-		if invokingResource then
-			lib.logger(inv.owner, 'removeItem',
-				('"%s" removed %sx %s from "%s"'):format(invokingResource, removed, item.name, inv.label))
-		end
+        if invokingResource then
+            lib.logger(inv.owner, 'removeItem',
+                ('"%s" removed %sx %s from "%s"'):format(invokingResource, removed, item.name, inv.label))
+        end
 
-		return true
-	end
+        return true
+    end
 
-	return false, 'not_enough_items'
+    return false, 'not_enough_items'
 end
 
 exports('RemoveItem', Inventory.RemoveItem)
@@ -1492,34 +1492,34 @@ exports('RemoveItem', Inventory.RemoveItem)
 ---@param count number
 ---@param metadata? table | string
 function Inventory.CanCarryItem(inv, item, count, metadata)
-	if type(item) ~= 'table' then item = Items(item) end
+    if type(item) ~= 'table' then item = Items(item) end
 
-	if item then
-		inv = Inventory(inv) --[[@as OxInventory]]
+    if item then
+        inv = Inventory(inv) --[[@as OxInventory]]
 
-		if inv then
-			local itemSlots, _, emptySlots = Inventory.GetItemSlots(inv, item,
-				type(metadata) == 'table' and metadata or { type = metadata or nil })
+        if inv then
+            local itemSlots, _, emptySlots = Inventory.GetItemSlots(inv, item,
+                type(metadata) == 'table' and metadata or { type = metadata or nil })
 
-			if not itemSlots then return end
+            if not itemSlots then return end
 
-			local weight = metadata and metadata.weight or item.weight
+            local weight = metadata and metadata.weight or item.weight
 
-			if next(itemSlots) or emptySlots > 0 then
-				if not count then count = 1 end
-				if not item.stack and emptySlots < count then return false end
-				if weight == 0 then return true end
+            if next(itemSlots) or emptySlots > 0 then
+                if not count then count = 1 end
+                if not item.stack and emptySlots < count then return false end
+                if weight == 0 then return true end
 
-				local newWeight = inv.weight + (weight * count)
+                local newWeight = inv.weight + (weight * count)
 
-				if newWeight > inv.maxWeight then
-					return false
-				end
+                if newWeight > inv.maxWeight then
+                    return false
+                end
 
-				return true
-			end
-		end
-	end
+                return true
+            end
+        end
+    end
 end
 
 exports('CanCarryItem', Inventory.CanCarryItem)
@@ -1527,13 +1527,13 @@ exports('CanCarryItem', Inventory.CanCarryItem)
 ---@param inv inventory
 ---@param item table | string
 function Inventory.CanCarryAmount(inv, item)
-	if type(item) ~= 'table' then item = Items(item) end
-	inv = Inventory(inv) --[[@as OxInventory]]
+    if type(item) ~= 'table' then item = Items(item) end
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if inv and item then
-		local availableWeight = inv.maxWeight - inv.weight
-		return math.floor(availableWeight / item.weight)
-	end
+    if inv and item then
+        local availableWeight = inv.maxWeight - inv.weight
+        return math.floor(availableWeight / item.weight)
+    end
 end
 
 exports('CanCarryAmount', Inventory.CanCarryAmount)
@@ -1541,13 +1541,13 @@ exports('CanCarryAmount', Inventory.CanCarryAmount)
 ---@param inv inventory
 ---@param weight number
 function Inventory.CanCarryWeight(inv, weight)
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if not inv then return end
+    if not inv then return end
 
-	local availableWeight = inv.maxWeight - inv.weight
-	local canHold = availableWeight >= weight
-	return canHold, availableWeight
+    local availableWeight = inv.maxWeight - inv.weight
+    local canHold = availableWeight >= weight
+    return canHold, availableWeight
 end
 
 exports('CanCarryWeight', Inventory.CanCarryWeight)
@@ -1558,18 +1558,18 @@ exports('CanCarryWeight', Inventory.CanCarryWeight)
 ---@param testItem string
 ---@param testItemCount number
 function Inventory.CanSwapItem(inv, firstItem, firstItemCount, testItem, testItemCount)
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if not inv then return end
+    if not inv then return end
 
-	local firstItemData = Inventory.GetItem(inv, firstItem)
-	local testItemData = Inventory.GetItem(inv, testItem)
+    local firstItemData = Inventory.GetItem(inv, firstItem)
+    local testItemData = Inventory.GetItem(inv, testItem)
 
-	if firstItemData and testItemData and firstItemData.count >= firstItemCount then
-		local weightWithoutFirst = inv.weight - (firstItemData.weight * firstItemCount)
-		local weightWithTest = weightWithoutFirst + (testItemData.weight * testItemCount)
-		return weightWithTest <= inv.maxWeight
-	end
+    if firstItemData and testItemData and firstItemData.count >= firstItemCount then
+        local weightWithoutFirst = inv.weight - (firstItemData.weight * firstItemCount)
+        local weightWithTest = weightWithoutFirst + (testItemData.weight * testItemCount)
+        return weightWithTest <= inv.maxWeight
+    end
 end
 
 exports('CanSwapItem', Inventory.CanSwapItem)
@@ -1580,7 +1580,7 @@ exports('CanSwapItem', Inventory.CanSwapItem)
 ---@param metadata { [string]: any }
 ---@param slot number
 RegisterServerEvent('ox_inventory:removeItem', function(name, count, metadata, slot)
-	Inventory.RemoveItem(source, name, count, metadata, slot)
+    Inventory.RemoveItem(source, name, count, metadata, slot)
 end)
 
 Inventory.Drops = {}
@@ -1588,60 +1588,60 @@ Inventory.Drops = {}
 ---@param prefix string?
 ---@return string
 local function generateInvId(prefix)
-	while true do
-		local invId = ('%s-%s'):format(prefix or 'drop', math.random(100000, 999999))
+    while true do
+        local invId = ('%s-%s'):format(prefix or 'drop', math.random(100000, 999999))
 
-		if not Inventories[invId] then return invId end
+        if not Inventories[invId] then return invId end
 
-		Wait(0)
-	end
+        Wait(0)
+    end
 end
 
 local function CustomDrop(prefix, items, coords, slots, maxWeight, instance, model)
-	local dropId = generateInvId()
-	local inventory = Inventory.Create(dropId, ('%s %s'):format(prefix, dropId:gsub('%D', '')), 'drop',
-		slots or shared.dropslots, 0, maxWeight or shared.dropweight, false, {})
+    local dropId = generateInvId()
+    local inventory = Inventory.Create(dropId, ('%s %s'):format(prefix, dropId:gsub('%D', '')), 'drop',
+        slots or shared.dropslots, 0, maxWeight or shared.dropweight, false, {})
 
-	if not inventory then return end
+    if not inventory then return end
 
-	inventory.items, inventory.weight = generateItems(inventory, 'drop', items)
-	inventory.coords = coords
-	Inventory.Drops[dropId] = {
-		coords = inventory.coords,
-		instance = instance,
-		model = model,
-	}
+    inventory.items, inventory.weight = generateItems(inventory, 'drop', items)
+    inventory.coords = coords
+    Inventory.Drops[dropId] = {
+        coords = inventory.coords,
+        instance = instance,
+        model = model,
+    }
 
-	TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId])
+    TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId])
 
-	return dropId
+    return dropId
 end
 
 AddEventHandler('ox_inventory:customDrop', CustomDrop)
 exports('CustomDrop', CustomDrop)
 
 exports('CreateDropFromPlayer', function(playerId)
-	local playerInventory = Inventory(playerId)
+    local playerInventory = Inventory(playerId)
 
-	if not playerInventory or not next(playerInventory.items) then return end
+    if not playerInventory or not next(playerInventory.items) then return end
 
-	local dropId = generateInvId()
-	local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop', playerInventory.slots,
-		playerInventory.weight, playerInventory.maxWeight, false, table.clone(playerInventory.items))
+    local dropId = generateInvId()
+    local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop', playerInventory.slots,
+        playerInventory.weight, playerInventory.maxWeight, false, table.clone(playerInventory.items))
 
-	if not inventory then return end
+    if not inventory then return end
 
-	local coords = GetEntityCoords(GetPlayerPed(playerId))
-	inventory.coords = vec3(coords.x, coords.y, coords.z - 0.2)
-	Inventory.Drops[dropId] = {
-		coords = inventory.coords,
-		instance = Player(playerId).state.instance
-	}
+    local coords = GetEntityCoords(GetPlayerPed(playerId))
+    inventory.coords = vec3(coords.x, coords.y, coords.z - 0.2)
+    Inventory.Drops[dropId] = {
+        coords = inventory.coords,
+        instance = Player(playerId).state.instance
+    }
 
-	Inventory.Clear(playerInventory)
-	TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId])
+    Inventory.Clear(playerInventory)
+    TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId])
 
-	return dropId
+    return dropId
 end)
 
 local TriggerEventHooks = require 'modules.hooks.server'
@@ -1660,77 +1660,77 @@ local TriggerEventHooks = require 'modules.hooks.server'
 ---@param fromData SlotWithItem?
 ---@param data SwapSlotData
 local function dropItem(source, playerInventory, fromData, data)
-	if not fromData then return end
+    if not fromData then return end
 
-	local toData = table.clone(fromData)
-	toData.slot = data.toSlot
-	toData.count = data.count
-	toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
+    local toData = table.clone(fromData)
+    toData.slot = data.toSlot
+    toData.count = data.count
+    toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
 
-	if toData.weight > shared.dropweight then return end
+    if toData.weight > shared.dropweight then return end
 
-	local dropId = generateInvId('drop')
+    local dropId = generateInvId('drop')
 
-	if not TriggerEventHooks('swapItems', {
-			source = source,
-			fromInventory = playerInventory.id,
-			fromSlot = fromData,
-			fromType = playerInventory.type,
-			toInventory = 'newdrop',
-			toSlot = data.toSlot,
-			toType = 'drop',
-			count = data.count,
-			action = 'move',
-			dropId = dropId,
-		}) then
-		return
-	end
+    if not TriggerEventHooks('swapItems', {
+            source = source,
+            fromInventory = playerInventory.id,
+            fromSlot = fromData,
+            fromType = playerInventory.type,
+            toInventory = 'newdrop',
+            toSlot = data.toSlot,
+            toType = 'drop',
+            count = data.count,
+            action = 'move',
+            dropId = dropId,
+        }) then
+        return
+    end
 
-	fromData.count -= data.count
-	fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
+    fromData.count -= data.count
+    fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
 
-	if fromData.count < 1 then
-		fromData = nil
-	else
-		toData.metadata = table.clone(toData.metadata)
-	end
+    if fromData.count < 1 then
+        fromData = nil
+    else
+        toData.metadata = table.clone(toData.metadata)
+    end
 
-	local slot = data.fromSlot
-	playerInventory.weight -= toData.weight
-	playerInventory.items[slot] = fromData
+    local slot = data.fromSlot
+    playerInventory.weight -= toData.weight
+    playerInventory.items[slot] = fromData
 
-	if slot == playerInventory.weapon then
-		playerInventory.weapon = nil
-	end
+    if slot == playerInventory.weapon then
+        playerInventory.weapon = nil
+    end
 
-	local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop', shared.dropslots,
-		toData.weight, shared.dropweight, false, { [data.toSlot] = toData })
+    local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop', shared.dropslots,
+        toData.weight, shared.dropweight, false, { [data.toSlot] = toData })
 
-	if not inventory then return end
+    if not inventory then return end
 
-	inventory.coords = data.coords
-	Inventory.Drops[dropId] = { coords = inventory.coords, instance = data.instance }
-	playerInventory.changed = true
+    inventory.coords = data.coords
+    Inventory.Drops[dropId] = { coords = inventory.coords, instance = data.instance }
+    playerInventory.changed = true
 
-	TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId], playerInventory.open and source,
-		slot)
+    TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId], playerInventory.open and source,
+        slot)
 
-	if server.loglevel > 0 then
-		lib.logger(playerInventory.owner, 'swapSlots',
-			('%sx %s transferred from "%s" to "%s"'):format(data.count, toData.name, playerInventory.label, dropId))
-	end
+    if server.loglevel > 0 then
+        lib.logger(playerInventory.owner, 'swapSlots',
+            ('%sx %s transferred from "%s" to "%s"'):format(data.count, toData.name, playerInventory.label, dropId))
+    end
 
-	if server.syncInventory then server.syncInventory(playerInventory) end
+    if server.syncInventory then server.syncInventory(playerInventory) end
 
-	return true, {
-		weight = playerInventory.weight,
-		items = {
-			{
-				item = fromData or { slot = data.fromSlot },
-				inventory = playerInventory.id
-			}
-		}
-	}
+    return true, {
+        weight = playerInventory.weight,
+        items = {
+            {
+                item = fromData or { slot = data.fromSlot },
+                inventory = playerInventory.id
+            }
+        }
+    }
 end
 
 local activeSlots = {}
@@ -1738,303 +1738,303 @@ local activeSlots = {}
 ---@param source number
 ---@param data SwapSlotData
 lib.callback.register('ox_inventory:swapItems', function(source, data)
-	if data.count < 1 then return end
+    if data.count < 1 then return end
 
-	local playerInventory = Inventory(source)
-	if not playerInventory then return end
+    local playerInventory = Inventory(source)
+    if not playerInventory then return end
 
-	local toInventory = (data.toType == 'player' and playerInventory) or Inventory(playerInventory.open)
-	local fromInventory = (data.fromType == 'player' and playerInventory) or Inventory(playerInventory.open)
+    local toInventory = (data.toType == 'player' and playerInventory) or Inventory(playerInventory.open)
+    local fromInventory = (data.fromType == 'player' and playerInventory) or Inventory(playerInventory.open)
 
-	if not fromInventory or not toInventory then
-		playerInventory:closeInventory()
-		return
-	end
+    if not fromInventory or not toInventory then
+        playerInventory:closeInventory()
+        return
+    end
 
-	if data.toType == 'inspect' or data.fromType == 'inspect' then return end
+    if data.toType == 'inspect' or data.fromType == 'inspect' then return end
 
-	local fromRef = ('%s:%s'):format(fromInventory.id, data.fromSlot)
-	local toRef = ('%s:%s'):format(toInventory.id, data.toSlot)
+    local fromRef = ('%s:%s'):format(fromInventory.id, data.fromSlot)
+    local toRef = ('%s:%s'):format(toInventory.id, data.toSlot)
 
-	if activeSlots[fromRef] or activeSlots[toRef] then
-		return false, {
-			{ item = toInventory.items[data.toSlot] or { slot = data.toSlot },       inventory = toInventory.id },
-			{ item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
-		}
-	end
+    if activeSlots[fromRef] or activeSlots[toRef] then
+        return false, {
+            { item = toInventory.items[data.toSlot] or { slot = data.toSlot },       inventory = toInventory.id },
+            { item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
+        }
+    end
 
-	local sameInventory = fromInventory.id == toInventory.id
-	local fromOtherPlayer = fromInventory.player and fromInventory ~= playerInventory
-	local toOtherPlayer = toInventory.player and toInventory ~= playerInventory
-	local toData = toInventory.items[data.toSlot]
+    local sameInventory = fromInventory.id == toInventory.id
+    local fromOtherPlayer = fromInventory.player and fromInventory ~= playerInventory
+    local toOtherPlayer = toInventory.player and toInventory ~= playerInventory
+    local toData = toInventory.items[data.toSlot]
 
-	if not sameInventory and (fromInventory.type == 'policeevidence' or (toInventory.type == 'policeevidence' and toData)) then
-		local group, rank = server.hasGroup(playerInventory, shared.police)
-		if not group or server.evidencegrade > rank then
-			return false, 'evidence_cannot_take'
-		end
-	end
+    if not sameInventory and (fromInventory.type == 'policeevidence' or (toInventory.type == 'policeevidence' and toData)) then
+        local group, rank = server.hasGroup(playerInventory, shared.police)
+        if not group or server.evidencegrade > rank then
+            return false, 'evidence_cannot_take'
+        end
+    end
 
-	activeSlots[fromRef] = true
-	activeSlots[toRef] = true
+    activeSlots[fromRef] = true
+    activeSlots[toRef] = true
 
-	local _ <close> = defer(function()
-		activeSlots[fromRef] = nil
-		activeSlots[toRef] = nil
-	end)
+    local _ <close> = defer(function()
+        activeSlots[fromRef] = nil
+        activeSlots[toRef] = nil
+    end)
 
-	if toInventory and (data.toType == 'newdrop' or fromInventory ~= toInventory or data.fromSlot ~= data.toSlot) then
-		local fromData = fromInventory.items[data.fromSlot]
+    if toInventory and (data.toType == 'newdrop' or fromInventory ~= toInventory or data.fromSlot ~= data.toSlot) then
+        local fromData = fromInventory.items[data.fromSlot]
 
-		if not fromData then
-			return false, {
-				{ item = { slot = data.fromSlot },         inventory = fromInventory.id },
-				{ item = toData or { slot = data.toSlot }, inventory = toInventory.id }
-			}
-		end
+        if not fromData then
+            return false, {
+                { item = { slot = data.fromSlot },         inventory = fromInventory.id },
+                { item = toData or { slot = data.toSlot }, inventory = toInventory.id }
+            }
+        end
 
-		if data.count > fromData.count then
-			data.count = fromData.count
-		end
+        if data.count > fromData.count then
+            data.count = fromData.count
+        end
 
-		if data.toType == 'newdrop' then
-			return dropItem(source, playerInventory, fromData, data)
-		end
+        if data.toType == 'newdrop' then
+            return dropItem(source, playerInventory, fromData, data)
+        end
 
-		if fromData then
-			if fromData.metadata.container and toInventory.type == 'container' then return false end
-			if toData and toData.metadata.container and fromInventory.type == 'container' then return false end
+        if fromData then
+            if fromData.metadata.container and toInventory.type == 'container' then return false end
+            if toData and toData.metadata.container and fromInventory.type == 'container' then return false end
 
-			local container, containerItem = (not sameInventory and playerInventory.containerSlot) and
-				(fromInventory.type == 'container' and fromInventory or toInventory)
+            local container, containerItem = (not sameInventory and playerInventory.containerSlot) and
+                (fromInventory.type == 'container' and fromInventory or toInventory)
 
-			if container then
-				containerItem = playerInventory.items[playerInventory.containerSlot]
-			end
+            if container then
+                containerItem = playerInventory.items[playerInventory.containerSlot]
+            end
 
-			local hookPayload = {
-				source = source,
-				fromInventory = fromInventory.id,
-				fromSlot = fromData,
-				fromType = fromInventory.type,
-				toInventory = toInventory.id,
-				toSlot = toData or data.toSlot,
-				toType = toInventory.type,
-				count = data.count,
-			}
+            local hookPayload = {
+                source = source,
+                fromInventory = fromInventory.id,
+                fromSlot = fromData,
+                fromType = fromInventory.type,
+                toInventory = toInventory.id,
+                toSlot = toData or data.toSlot,
+                toType = toInventory.type,
+                count = data.count,
+            }
 
-			if toData and ((toData.name ~= fromData.name) or not toData.stack or (not table.matches(toData.metadata, fromData.metadata))) then
-				local toWeight = not sameInventory and (toInventory.weight - toData.weight + fromData.weight) or 0
-				local fromWeight = not sameInventory and (fromInventory.weight + toData.weight - fromData.weight) or 0
-				hookPayload.action = 'swap'
+            if toData and ((toData.name ~= fromData.name) or not toData.stack or (not table.matches(toData.metadata, fromData.metadata))) then
+                local toWeight = not sameInventory and (toInventory.weight - toData.weight + fromData.weight) or 0
+                local fromWeight = not sameInventory and (fromInventory.weight + toData.weight - fromData.weight) or 0
+                hookPayload.action = 'swap'
 
-				if not sameInventory then
-					if (toWeight <= toInventory.maxWeight and fromWeight <= fromInventory.maxWeight) then
-						if not TriggerEventHooks('swapItems', hookPayload) then return end
-						if containerItem then
-							local toContainer = toInventory.type == 'container'
-							local whitelist = Items.containers[containerItem.name]?.whitelist
-							local blacklist = Items.containers[containerItem.name]?.blacklist
-							local checkItem = toContainer and fromData.name or toData.name
-							if (whitelist and not whitelist[checkItem]) or (blacklist and blacklist[checkItem]) then return end
-							Inventory.ContainerWeight(containerItem, toContainer and toWeight or fromWeight,
-								playerInventory)
-						end
-						fromInventory.weight = fromWeight
-						toInventory.weight = toWeight
-						toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
-					else
-						return false, 'cannot_carry'
-					end
-				else
-					if not TriggerEventHooks('swapItems', hookPayload) then return end
-					toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
-				end
-			elseif toData and toData.name == fromData.name and table.matches(toData.metadata, fromData.metadata) then
-				local maxStack = (type(toData.stack) == 'number' and toData.stack) or false
-				if maxStack then
-					local spaceLeft = maxStack - toData.count
-					if spaceLeft <= 0 then return false, 'stack_full' end
+                if not sameInventory then
+                    if (toWeight <= toInventory.maxWeight and fromWeight <= fromInventory.maxWeight) then
+                        if not TriggerEventHooks('swapItems', hookPayload) then return end
+                        if containerItem then
+                            local toContainer = toInventory.type == 'container'
+                            local whitelist = Items.containers[containerItem.name]?.whitelist
+                            local blacklist = Items.containers[containerItem.name]?.blacklist
+                            local checkItem = toContainer and fromData.name or toData.name
+                            if (whitelist and not whitelist[checkItem]) or (blacklist and blacklist[checkItem]) then return end
+                            Inventory.ContainerWeight(containerItem, toContainer and toWeight or fromWeight,
+                                playerInventory)
+                        end
+                        fromInventory.weight = fromWeight
+                        toInventory.weight = toWeight
+                        toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
+                    else
+                        return false, 'cannot_carry'
+                    end
+                else
+                    if not TriggerEventHooks('swapItems', hookPayload) then return end
+                    toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
+                end
+            elseif toData and toData.name == fromData.name and table.matches(toData.metadata, fromData.metadata) then
+                local maxStack = (type(toData.stack) == 'number' and toData.stack) or false
+                if maxStack then
+                    local spaceLeft = maxStack - toData.count
+                    if spaceLeft <= 0 then return false, 'stack_full' end
 
-					local moveAmount = math.min(data.count, fromData.count, spaceLeft)
-					toData.count = toData.count + moveAmount
-					fromData.count = fromData.count - moveAmount
-					if fromData.count > 0 then
-						toData.metadata = table.clone(toData.metadata)
-						fromData.metadata = table.clone(fromData.metadata)
-					end
-					toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
-					fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
-					hookPayload.action = 'stackItems'
-					hookPayload.moved = moveAmount
-					hookPayload.leftover = data.count - moveAmount
-					if not TriggerEventHooks('swapItems', hookPayload) then return end
-				else
-					local tempCount, tempWeight = toData.count, toData.weight
-					toData.count = fromData.count
-					toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
-					fromData.count = tempCount
-					fromData.weight = tempWeight
+                    local moveAmount = math.min(data.count, fromData.count, spaceLeft)
+                    toData.count = toData.count + moveAmount
+                    fromData.count = fromData.count - moveAmount
+                    if fromData.count > 0 then
+                        toData.metadata = table.clone(toData.metadata)
+                        fromData.metadata = table.clone(fromData.metadata)
+                    end
+                    toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
+                    fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
+                    hookPayload.action = 'stackItems'
+                    hookPayload.moved = moveAmount
+                    hookPayload.leftover = data.count - moveAmount
+                    if not TriggerEventHooks('swapItems', hookPayload) then return end
+                else
+                    local tempCount, tempWeight = toData.count, toData.weight
+                    toData.count = fromData.count
+                    toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
+                    fromData.count = tempCount
+                    fromData.weight = tempWeight
 
-					hookPayload.action = 'swapCounts'
-					if not TriggerEventHooks('swapItems', hookPayload) then return end
-				end
-			elseif data.count <= fromData.count then
-				toData = table.clone(fromData)
-				toData.count = data.count
-				toData.slot = data.toSlot
-				toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
-				if fromInventory.type == 'container' or sameInventory or (toInventory.weight + toData.weight <= toInventory.maxWeight) then
-					hookPayload.action = 'move'
-					if not TriggerEventHooks('swapItems', hookPayload) then return end
-					fromInventory.weight -= toData.weight
-					toInventory.weight += toData.weight
-					fromData.count -= data.count
-					fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
-					if fromData.count > 0 then
-						toData.metadata = table.clone(toData.metadata)
-					end
-				else
-					return false, 'cannot_carry_other'
-				end
-			end
+                    hookPayload.action = 'swapCounts'
+                    if not TriggerEventHooks('swapItems', hookPayload) then return end
+                end
+            elseif data.count <= fromData.count then
+                toData = table.clone(fromData)
+                toData.count = data.count
+                toData.slot = data.toSlot
+                toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
+                if fromInventory.type == 'container' or sameInventory or (toInventory.weight + toData.weight <= toInventory.maxWeight) then
+                    hookPayload.action = 'move'
+                    if not TriggerEventHooks('swapItems', hookPayload) then return end
+                    fromInventory.weight -= toData.weight
+                    toInventory.weight += toData.weight
+                    fromData.count -= data.count
+                    fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
+                    if fromData.count > 0 then
+                        toData.metadata = table.clone(toData.metadata)
+                    end
+                else
+                    return false, 'cannot_carry_other'
+                end
+            end
 
-			if fromData and fromData.count < 1 then fromData = nil end
+            if fromData and fromData.count < 1 then fromData = nil end
 
-			local items = {}
-			if fromInventory.player and not fromOtherPlayer then
-				if toInventory.type == 'container' and containerItem then
-					items[#items + 1] = { item = containerItem, inventory = playerInventory.id }
-				end
-			end
-			if toInventory.player and not toOtherPlayer then
-				if fromInventory.type == 'container' and containerItem then
-					items[#items + 1] = { item = containerItem, inventory = playerInventory.id }
-				end
-			end
+            local items = {}
+            if fromInventory.player and not fromOtherPlayer then
+                if toInventory.type == 'container' and containerItem then
+                    items[#items + 1] = { item = containerItem, inventory = playerInventory.id }
+                end
+            end
+            if toInventory.player and not toOtherPlayer then
+                if fromInventory.type == 'container' and containerItem then
+                    items[#items + 1] = { item = containerItem, inventory = playerInventory.id }
+                end
+            end
 
-			fromInventory.items[data.fromSlot] = fromData
-			toInventory.items[data.toSlot] = toData
+            fromInventory.items[data.fromSlot] = fromData
+            toInventory.items[data.toSlot] = toData
 
-			if fromInventory.changed ~= nil then fromInventory.changed = true end
-			if toInventory.changed ~= nil then toInventory.changed = true end
+            if fromInventory.changed ~= nil then fromInventory.changed = true end
+            if toInventory.changed ~= nil then toInventory.changed = true end
 
-			CreateThread(function()
-				if sameInventory then
-					fromInventory:syncSlotsWithClients({
-						{ item = fromInventory.items[data.toSlot] or { slot = data.toSlot },     inventory = fromInventory.id },
-						{ item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
-					}, true)
-				else
-					toInventory:syncSlotsWithClients({
-						{ item = toInventory.items[data.toSlot] or { slot = data.toSlot }, inventory = toInventory.id }
-					}, true)
-					fromInventory:syncSlotsWithClients({
-						{ item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
-					}, true)
-				end
-			end)
+            CreateThread(function()
+                if sameInventory then
+                    fromInventory:syncSlotsWithClients({
+                        { item = fromInventory.items[data.toSlot] or { slot = data.toSlot },     inventory = fromInventory.id },
+                        { item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
+                    }, true)
+                else
+                    toInventory:syncSlotsWithClients({
+                        { item = toInventory.items[data.toSlot] or { slot = data.toSlot }, inventory = toInventory.id }
+                    }, true)
+                    fromInventory:syncSlotsWithClients({
+                        { item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
+                    }, true)
+                end
+            end)
 
-			local resp
-			if next(items) then
-				resp = { weight = playerInventory.weight, items = items }
-			end
+            local resp
+            if next(items) then
+                resp = { weight = playerInventory.weight, items = items }
+            end
 
-			if server.syncInventory then
-				if fromInventory.player then server.syncInventory(fromInventory) end
-				if toInventory.player and not sameInventory then server.syncInventory(toInventory) end
-			end
+            if server.syncInventory then
+                if fromInventory.player then server.syncInventory(fromInventory) end
+                if toInventory.player and not sameInventory then server.syncInventory(toInventory) end
+            end
 
-			local weaponSlot
-			if toInventory.weapon == data.toSlot then
-				if not sameInventory then
-					toInventory.weapon = nil
-					TriggerClientEvent('ox_inventory:disarm', toInventory.id)
-				else
-					weaponSlot = data.fromSlot
-					toInventory.weapon = weaponSlot
-				end
-			end
-			if fromInventory.weapon == data.fromSlot then
-				if not sameInventory then
-					fromInventory.weapon = nil
-					TriggerClientEvent('ox_inventory:disarm', fromInventory.id)
-				elseif not weaponSlot then
-					weaponSlot = data.toSlot
-					fromInventory.weapon = weaponSlot
-				end
-			end
+            local weaponSlot
+            if toInventory.weapon == data.toSlot then
+                if not sameInventory then
+                    toInventory.weapon = nil
+                    TriggerClientEvent('ox_inventory:disarm', toInventory.id)
+                else
+                    weaponSlot = data.fromSlot
+                    toInventory.weapon = weaponSlot
+                end
+            end
+            if fromInventory.weapon == data.fromSlot then
+                if not sameInventory then
+                    fromInventory.weapon = nil
+                    TriggerClientEvent('ox_inventory:disarm', fromInventory.id)
+                elseif not weaponSlot then
+                    weaponSlot = data.toSlot
+                    fromInventory.weapon = weaponSlot
+                end
+            end
 
-			return containerItem and containerItem.weight or true, resp, weaponSlot
-		end
-	end
+            return containerItem and containerItem.weight or true, resp, weaponSlot
+        end
+    end
 end)
 
 function Inventory.Confiscate(source)
-	local inv = Inventory(source)
+    local inv = Inventory(source)
 
-	if inv?.player then
-		db.saveStash(inv.owner, inv.owner, json.encode(minimal(inv)))
-		table.wipe(inv.items)
-		inv.weight = 0
-		inv.changed = true
+    if inv?.player then
+        db.saveStash(inv.owner, inv.owner, json.encode(minimal(inv)))
+        table.wipe(inv.items)
+        inv.weight = 0
+        inv.changed = true
 
-		TriggerClientEvent('ox_inventory:inventoryConfiscated', inv.id)
+        TriggerClientEvent('ox_inventory:inventoryConfiscated', inv.id)
 
-		if server.syncInventory then server.syncInventory(inv) end
-	end
+        if server.syncInventory then server.syncInventory(inv) end
+    end
 end
 
 exports('ConfiscateInventory', Inventory.Confiscate)
 
 function Inventory.Return(source)
-	local inv = Inventory(source)
+    local inv = Inventory(source)
 
-	if not inv?.player then return end
+    if not inv?.player then return end
 
-	local items = MySQL.scalar.await('SELECT data FROM ox_inventory WHERE name = ?', { inv.owner })
+    local items = MySQL.scalar.await('SELECT data FROM ox_inventory WHERE name = ?', { inv.owner })
 
-	if not items then return end
+    if not items then return end
 
-	MySQL.update.await('DELETE FROM ox_inventory WHERE name = ?', { inv.owner })
+    MySQL.update.await('DELETE FROM ox_inventory WHERE name = ?', { inv.owner })
 
-	items = json.decode(items)
-	local inventory, totalWeight = {}, 0
+    items = json.decode(items)
+    local inventory, totalWeight = {}, 0
 
-	if table.type(items) == 'array' then
-		for i = 1, #items do
-			local data = items[i]
-			if type(data) == 'number' then break end
+    if table.type(items) == 'array' then
+        for i = 1, #items do
+            local data = items[i]
+            if type(data) == 'number' then break end
 
-			local item = Items(data.name)
+            local item = Items(data.name)
 
-			if item then
-				local weight = Inventory.SlotWeight(item, data)
-				totalWeight = totalWeight + weight
-				inventory[data.slot] = {
-					name = data.name,
-					label = item.label,
-					weight = weight,
-					slot = data.slot,
-					count =
-						data.count,
-					description = item.description,
-					metadata = data.metadata,
-					stack = item.stack,
-					close = item
-						.close
-				}
-			end
-		end
-	end
+            if item then
+                local weight = Inventory.SlotWeight(item, data)
+                totalWeight = totalWeight + weight
+                inventory[data.slot] = {
+                    name = data.name,
+                    label = item.label,
+                    weight = weight,
+                    slot = data.slot,
+                    count =
+                        data.count,
+                    description = item.description,
+                    metadata = data.metadata,
+                    stack = item.stack,
+                    close = item
+                        .close
+                }
+            end
+        end
+    end
 
-	inv.changed = true
-	inv.weight = totalWeight
-	inv.items = inventory
+    inv.changed = true
+    inv.weight = totalWeight
+    inv.items = inventory
 
-	TriggerClientEvent('ox_inventory:inventoryReturned', source, { inventory, totalWeight })
+    TriggerClientEvent('ox_inventory:inventoryReturned', source, { inventory, totalWeight })
 
-	if server.syncInventory then server.syncInventory(inv) end
+    if server.syncInventory then server.syncInventory(inv) end
 end
 
 exports('ReturnInventory', Inventory.Return)
@@ -2042,82 +2042,82 @@ exports('ReturnInventory', Inventory.Return)
 ---@param inv inventory
 ---@param keep? string | string[] an item or list of items to ignore while clearing items
 function Inventory.Clear(inv, keep)
-	inv = Inventory(inv) --[[@as OxInventory]]
+    inv = Inventory(inv) --[[@as OxInventory]]
 
-	if not inv or not next(inv.items) then return end
+    if not inv or not next(inv.items) then return end
 
-	local updateSlots = {}
-	local newWeight = 0
-	local inc = 0
+    local updateSlots = {}
+    local newWeight = 0
+    local inc = 0
 
-	if keep then
-		local keptItems = {}
-		local keepType = type(keep)
+    if keep then
+        local keptItems = {}
+        local keepType = type(keep)
 
-		if keepType == 'string' then
-			for slot, v in pairs(inv.items) do
-				if v.name == keep then
-					keptItems[v.slot] = v
-					newWeight += v.weight
-				elseif updateSlots then
-					inc += 1
-					updateSlots[inc] = { item = { slot = slot }, inventory = inv.id }
-				end
-			end
-		elseif keepType == 'table' and table.type(keep) == 'array' then
-			for slot, v in pairs(inv.items) do
-				for i = 1, #keep do
-					if v.name == keep[i] then
-						keptItems[v.slot] = v
-						newWeight += v.weight
-						goto foundItem
-					end
-				end
+        if keepType == 'string' then
+            for slot, v in pairs(inv.items) do
+                if v.name == keep then
+                    keptItems[v.slot] = v
+                    newWeight += v.weight
+                elseif updateSlots then
+                    inc += 1
+                    updateSlots[inc] = { item = { slot = slot }, inventory = inv.id }
+                end
+            end
+        elseif keepType == 'table' and table.type(keep) == 'array' then
+            for slot, v in pairs(inv.items) do
+                for i = 1, #keep do
+                    if v.name == keep[i] then
+                        keptItems[v.slot] = v
+                        newWeight += v.weight
+                        goto foundItem
+                    end
+                end
 
-				if updateSlots then
-					inc += 1
-					updateSlots[inc] = { item = { slot = slot }, inventory = inv.id }
-				end
+                if updateSlots then
+                    inc += 1
+                    updateSlots[inc] = { item = { slot = slot }, inventory = inv.id }
+                end
 
-				::foundItem::
-			end
-		end
+                ::foundItem::
+            end
+        end
 
-		table.wipe(inv.items)
-		inv.items = keptItems
-	else
-		if updateSlots then
-			for slot in pairs(inv.items) do
-				inc += 1
-				updateSlots[inc] = { item = { slot = slot }, inventory = inv.id }
-			end
-		end
+        table.wipe(inv.items)
+        inv.items = keptItems
+    else
+        if updateSlots then
+            for slot in pairs(inv.items) do
+                inc += 1
+                updateSlots[inc] = { item = { slot = slot }, inventory = inv.id }
+            end
+        end
 
-		table.wipe(inv.items)
-	end
+        table.wipe(inv.items)
+    end
 
-	inv.weight = newWeight
-	inv.changed = true
+    inv.weight = newWeight
+    inv.changed = true
 
-	inv:syncSlotsWithClients(updateSlots, true)
+    inv:syncSlotsWithClients(updateSlots, true)
 
-	if not inv.player then
-		if inv.open then
-			local playerInv = Inventory(inv.open)
+    if not inv.player then
+        if inv.open then
+            local playerInv = Inventory(inv.open)
 
-			if not playerInv then return end
+            if not playerInv then return end
 
-			playerInv:closeInventory()
-		end
+            playerInv:closeInventory()
+        end
 
-		inv:openInventory(inv)
+        inv:openInventory(inv)
 
-		return
-	end
+        return
+    end
 
-	if server.syncInventory then server.syncInventory(inv) end
+    if server.syncInventory then server.syncInventory(inv) end
 
-	inv.weapon = nil
+    inv.weapon = nil
 end
 
 exports('ClearInventory', Inventory.Clear)
@@ -2125,17 +2125,17 @@ exports('ClearInventory', Inventory.Clear)
 ---@param inv inventory
 ---@return integer?
 function Inventory.GetEmptySlot(inv)
-	local inventory = Inventory(inv)
+    local inventory = Inventory(inv)
 
-	if not inventory then return end
+    if not inventory then return end
 
-	local items = inventory.items
+    local items = inventory.items
 
-	for i = 1, inventory.slots do
-		if not items[i] then
-			return i
-		end
-	end
+    for i = 1, inventory.slots do
+        if not items[i] then
+            return i
+        end
+    end
 end
 
 exports('GetEmptySlot', Inventory.GetEmptySlot)
@@ -2144,28 +2144,28 @@ exports('GetEmptySlot', Inventory.GetEmptySlot)
 ---@param itemName string
 ---@param metadata any
 function Inventory.GetSlotForItem(inv, itemName, metadata)
-	local inventory = Inventory(inv)
-	local item = Items(itemName) --[[@as OxServerItem?]]
+    local inventory = Inventory(inv)
+    local item = Items(itemName) --[[@as OxServerItem?]]
 
-	if not inventory or not item then return end
+    if not inventory or not item then return end
 
-	metadata = assertMetadata(metadata)
-	local items = inventory.items
-	local emptySlot
+    metadata = assertMetadata(metadata)
+    local items = inventory.items
+    local emptySlot
 
-	for i = 1, inventory.slots do
-		local slotData = items[i]
+    for i = 1, inventory.slots do
+        local slotData = items[i]
 
-		if item.stack and slotData and slotData.name == item.name and table.matches(slotData.metadata, metadata) then
-			if slotData.count < (slotData.stack or item.stack) then
-				return i
-			end
-		elseif not slotData and not emptySlot then
-			emptySlot = i
-		end
-	end
+        if item.stack and slotData and slotData.name == item.name and table.matches(slotData.metadata, metadata) then
+            if slotData.count < (slotData.stack or item.stack) then
+                return i
+            end
+        elseif not slotData and not emptySlot then
+            emptySlot = i
+        end
+    end
 
-	return emptySlot
+    return emptySlot
 end
 
 exports('GetSlotForItem', Inventory.GetSlotForItem)
@@ -2176,21 +2176,21 @@ exports('GetSlotForItem', Inventory.GetSlotForItem)
 ---@param strict? boolean Strictly match metadata properties, otherwise use partial matching.
 ---@return SlotWithItem?
 function Inventory.GetSlotWithItem(inv, itemName, metadata, strict)
-	local inventory = Inventory(inv)
-	local item = Items(itemName) --[[@as OxServerItem?]]
+    local inventory = Inventory(inv)
+    local item = Items(itemName) --[[@as OxServerItem?]]
 
-	if not inventory or not item then return end
+    if not inventory or not item then return end
 
-	metadata = assertMetadata(metadata)
-	local tablematch = strict and table.matches or table.contains
+    metadata = assertMetadata(metadata)
+    local tablematch = strict and table.matches or table.contains
 
-	for _, slotData in pairs(inventory.items) do
-		if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
-			if not Items.UpdateDurability(inventory, slotData, item, nil, os.time()) then
-				return slotData
-			end
-		end
-	end
+    for _, slotData in pairs(inventory.items) do
+        if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
+            if not Items.UpdateDurability(inventory, slotData, item, nil, os.time()) then
+                return slotData
+            end
+        end
+    end
 end
 
 exports('GetSlotWithItem', Inventory.GetSlotWithItem)
@@ -2201,7 +2201,7 @@ exports('GetSlotWithItem', Inventory.GetSlotWithItem)
 ---@param strict? boolean Strictly match metadata properties, otherwise use partial matching.
 ---@return number?
 function Inventory.GetSlotIdWithItem(inv, itemName, metadata, strict)
-	return Inventory.GetSlotWithItem(inv, itemName, metadata, strict)?.slot
+    return Inventory.GetSlotWithItem(inv, itemName, metadata, strict)?.slot
 end
 
 exports('GetSlotIdWithItem', Inventory.GetSlotIdWithItem)
@@ -2212,26 +2212,26 @@ exports('GetSlotIdWithItem', Inventory.GetSlotIdWithItem)
 ---@param strict? boolean Strictly match metadata properties, otherwise use partial matching.
 ---@return SlotWithItem[]?
 function Inventory.GetSlotsWithItem(inv, itemName, metadata, strict)
-	local inventory = Inventory(inv)
-	local item = Items(itemName) --[[@as OxServerItem?]]
+    local inventory = Inventory(inv)
+    local item = Items(itemName) --[[@as OxServerItem?]]
 
-	if not inventory or not item then return end
+    if not inventory or not item then return end
 
-	metadata = assertMetadata(metadata)
-	local response = {}
-	local n = 0
-	local tablematch = strict and table.matches or table.contains
+    metadata = assertMetadata(metadata)
+    local response = {}
+    local n = 0
+    local tablematch = strict and table.matches or table.contains
 
-	for _, slotData in pairs(inventory.items) do
-		if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
-			if not Items.UpdateDurability(inventory, slotData, item, nil, os.time()) then
-				n += 1
-				response[n] = slotData
-			end
-		end
-	end
+    for _, slotData in pairs(inventory.items) do
+        if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
+            if not Items.UpdateDurability(inventory, slotData, item, nil, os.time()) then
+                n += 1
+                response[n] = slotData
+            end
+        end
+    end
 
-	return response
+    return response
 end
 
 exports('GetSlotsWithItem', Inventory.GetSlotsWithItem)
@@ -2242,16 +2242,16 @@ exports('GetSlotsWithItem', Inventory.GetSlotsWithItem)
 ---@param strict? boolean Strictly match metadata properties, otherwise use partial matching.
 ---@return number[]?
 function Inventory.GetSlotIdsWithItem(inv, itemName, metadata, strict)
-	local items = Inventory.GetSlotsWithItem(inv, itemName, metadata, strict)
+    local items = Inventory.GetSlotsWithItem(inv, itemName, metadata, strict)
 
-	if items then
-		---@cast items +number[]
-		for i = 1, #items do
-			items[i] = items[i].slot
-		end
+    if items then
+        ---@cast items +number[]
+        for i = 1, #items do
+            items[i] = items[i].slot
+        end
 
-		return items
-	end
+        return items
+    end
 end
 
 exports('GetSlotIdsWithItem', Inventory.GetSlotIdsWithItem)
@@ -2262,22 +2262,22 @@ exports('GetSlotIdsWithItem', Inventory.GetSlotIdsWithItem)
 ---@param strict? boolean Strictly match metadata properties, otherwise use partial matching.
 ---@return number
 function Inventory.GetItemCount(inv, itemName, metadata, strict)
-	local inventory = Inventory(inv)
-	local item = Items(itemName) --[[@as OxServerItem?]]
+    local inventory = Inventory(inv)
+    local item = Items(itemName) --[[@as OxServerItem?]]
 
-	if not inventory or not item then return 0 end
+    if not inventory or not item then return 0 end
 
-	metadata = assertMetadata(metadata)
-	local count = 0
-	local tablematch = strict and table.matches or table.contains
+    metadata = assertMetadata(metadata)
+    local count = 0
+    local tablematch = strict and table.matches or table.contains
 
-	for _, slotData in pairs(inventory.items) do
-		if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
-			count += slotData.count
-		end
-	end
+    for _, slotData in pairs(inventory.items) do
+        if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
+            count += slotData.count
+        end
+    end
 
-	return count
+    return count
 end
 
 exports('GetItemCount', Inventory.GetItemCount)
@@ -2290,396 +2290,396 @@ exports('GetItemCount', Inventory.GetItemCount)
 ---@return integer?
 ---@return InventorySaveData?
 local function prepareInventorySave(inv, buffer, time)
-	local shouldSave = not inv.datastore and inv.changed
-	local n = 0
+    local shouldSave = not inv.datastore and inv.changed
+    local n = 0
 
-	for k, v in pairs(inv.items) do
-		if not Items.UpdateDurability(inv, v, Items(v.name), nil, time) and shouldSave then
-			n += 1
-			buffer[n] = {
-				name = v.name,
-				count = v.count,
-				slot = k,
-				metadata = next(v.metadata) and v.metadata or nil
-			}
-		end
-	end
+    for k, v in pairs(inv.items) do
+        if not Items.UpdateDurability(inv, v, Items(v.name), nil, time) and shouldSave then
+            n += 1
+            buffer[n] = {
+                name = v.name,
+                count = v.count,
+                slot = k,
+                metadata = next(v.metadata) and v.metadata or nil
+            }
+        end
+    end
 
-	if not shouldSave then return end
+    if not shouldSave then return end
 
-	local data = next(buffer) and json.encode(buffer) or nil
-	inv.changed = false
-	table.wipe(buffer)
+    local data = next(buffer) and json.encode(buffer) or nil
+    inv.changed = false
+    table.wipe(buffer)
 
-	if inv.player then
-		if shared.framework == 'esx' then return end
+    if inv.player then
+        if shared.framework == 'esx' then return end
 
-		return 1, { data, inv.owner }
-	end
+        return 1, { data, inv.owner }
+    end
 
-	if inv.type == 'trunk' then
-		return 2, { data, inv.dbId }
-	end
+    if inv.type == 'trunk' then
+        return 2, { data, inv.dbId }
+    end
 
-	if inv.type == 'glovebox' then
-		return 3, { data, inv.dbId }
-	end
+    if inv.type == 'glovebox' then
+        return 3, { data, inv.dbId }
+    end
 
-	return 4, { data, inv.owner and tostring(inv.owner) or '', inv.dbId }
+    return 4, { data, inv.owner and tostring(inv.owner) or '', inv.dbId }
 end
 
 local isSaving = false
 local inventoryClearTime = GetConvarInt('inventory:cleartime', 5) * 60
 
 local function saveInventories(clearInventories)
-	if isSaving then return end
+    if isSaving then return end
 
-	local time = os.time()
-	local parameters = { {}, {}, {}, {} }
-	local total = { 0, 0, 0, 0, 0 }
-	local buffer = {}
+    local time = os.time()
+    local parameters = { {}, {}, {}, {} }
+    local total = { 0, 0, 0, 0, 0 }
+    local buffer = {}
 
-	for _, inv in pairs(Inventories) do
-		local index, data = prepareInventorySave(inv, buffer, time)
+    for _, inv in pairs(Inventories) do
+        local index, data = prepareInventorySave(inv, buffer, time)
 
-		if index and data then
-			total[5] += 1
+        if index and data then
+            total[5] += 1
 
-			if index == 4 and server.bulkstashsave then
-				for i = 1, 3 do
-					total[index] += 1
-					parameters[index][total[index]] = data[i]
-				end
-			else
-				total[index] += 1
-				parameters[index][total[index]] = data
-			end
-		end
-	end
+            if index == 4 and server.bulkstashsave then
+                for i = 1, 3 do
+                    total[index] += 1
+                    parameters[index][total[index]] = data[i]
+                end
+            else
+                total[index] += 1
+                parameters[index][total[index]] = data
+            end
+        end
+    end
 
-	if total[5] > 0 then
-		isSaving = true
-		local ok, err = pcall(db.saveInventories, parameters[1], parameters[2], parameters[3], parameters[4], total)
-		isSaving = false
+    if total[5] > 0 then
+        isSaving = true
+        local ok, err = pcall(db.saveInventories, parameters[1], parameters[2], parameters[3], parameters[4], total)
+        isSaving = false
 
-		if not ok and err then return lib.print.error(err) end
-	end
+        if not ok and err then return lib.print.error(err) end
+    end
 
-	if not clearInventories then return end
+    if not clearInventories then return end
 
-	for _, inv in pairs(Inventories) do
-		if not inv.open and not inv.player then
-			-- clear inventory from memory if unused for x minutes, or on entity/netid mismatch
-			if inv.type == 'glovebox' or inv.type == 'trunk' then
-				if NetworkGetEntityFromNetworkId(inv.netid) ~= inv.entityId then
-					Inventory.Remove(inv)
-				end
-			elseif time - inv.time >= inventoryClearTime then
-				Inventory.Remove(inv)
-			end
-		end
-	end
+    for _, inv in pairs(Inventories) do
+        if not inv.open and not inv.player then
+            -- clear inventory from memory if unused for x minutes, or on entity/netid mismatch
+            if inv.type == 'glovebox' or inv.type == 'trunk' then
+                if NetworkGetEntityFromNetworkId(inv.netid) ~= inv.entityId then
+                    Inventory.Remove(inv)
+                end
+            elseif time - inv.time >= inventoryClearTime then
+                Inventory.Remove(inv)
+            end
+        end
+    end
 end
 
 lib.cron.new('*/5 * * * *', function()
-	saveInventories(true)
+    saveInventories(true)
 end)
 
 function Inventory.SaveInventories(lock, clearInventories)
-	Inventory.Lock = lock or nil
+    Inventory.Lock = lock or nil
 
-	Inventory.CloseAll()
-	saveInventories(clearInventories)
+    Inventory.CloseAll()
+    saveInventories(clearInventories)
 end
 
 AddEventHandler('playerDropped', function()
-	server.playerDropped(source)
+    server.playerDropped(source)
 
-	if GetNumPlayerIndices() == 0 then
-		Inventory.SaveInventories(false, true)
-	end
+    if GetNumPlayerIndices() == 0 then
+        Inventory.SaveInventories(false, true)
+    end
 end)
 
 AddEventHandler('txAdmin:events:serverShuttingDown', function()
-	Inventory.SaveInventories(true, false)
+    Inventory.SaveInventories(true, false)
 end)
 
 AddEventHandler('txAdmin:events:scheduledRestart', function(eventData)
-	if eventData.secondsRemaining ~= 60 then return end
+    if eventData.secondsRemaining ~= 60 then return end
 
-	Inventory.SaveInventories(true, true)
+    Inventory.SaveInventories(true, true)
 end)
 
 AddEventHandler('onResourceStop', function(resource)
-	if resource == shared.resource then
-		Inventory.SaveInventories(true, false)
-	end
+    if resource == shared.resource then
+        Inventory.SaveInventories(true, false)
+    end
 end)
 
 RegisterServerEvent('ox_inventory:closeInventory', function()
-	local inventory = Inventories[source]
+    local inventory = Inventories[source]
 
-	if inventory?.open then
-		local secondary = Inventories[inventory.open]
+    if inventory?.open then
+        local secondary = Inventories[inventory.open]
 
-		if secondary then
-			secondary:closeInventory()
-		end
+        if secondary then
+            secondary:closeInventory()
+        end
 
-		inventory:closeInventory(true)
-	end
+        inventory:closeInventory(true)
+    end
 end)
 
 local function giveItem(playerId, slot, target, count)
-	local fromInventory = Inventory(playerId)
-	local toInventory = Inventory(target)
+    local fromInventory = Inventory(playerId)
+    local toInventory = Inventory(target)
 
-	if not fromInventory or not toInventory then return end
+    if not fromInventory or not toInventory then return end
 
-	if type(count) ~= 'number' or count <= 0 then count = 1 end
+    if type(count) ~= 'number' or count <= 0 then count = 1 end
 
-	if toInventory.player then
-		local data = fromInventory.items[slot]
+    if toInventory.player then
+        local data = fromInventory.items[slot]
 
-		if not data then return end
+        if not data then return end
 
-		local targetState = Player(target).state
+        local targetState = Player(target).state
 
-		if targetState.invBusy then
-			return { 'cannot_give', count, data.label }
-		end
+        if targetState.invBusy then
+            return { 'cannot_give', count, data.label }
+        end
 
-		local item = Items(data.name)
+        local item = Items(data.name)
 
-		if not item or data.count < count or not Inventory.CanCarryItem(toInventory, item, count, data.metadata) or #(GetEntityCoords(fromInventory.player.ped) - GetEntityCoords(toInventory.player.ped)) > 15 then
-			return { 'cannot_give', count, data.label }
-		end
+        if not item or data.count < count or not Inventory.CanCarryItem(toInventory, item, count, data.metadata) or #(GetEntityCoords(fromInventory.player.ped) - GetEntityCoords(toInventory.player.ped)) > 15 then
+            return { 'cannot_give', count, data.label }
+        end
 
-		local toSlot = Inventory.GetSlotForItem(toInventory, data.name, data.metadata)
-		local fromRef = ('%s:%s'):format(fromInventory.id, slot)
-		local toRef = ('%s:%s'):format(toInventory.id, toSlot)
+        local toSlot = Inventory.GetSlotForItem(toInventory, data.name, data.metadata)
+        local fromRef = ('%s:%s'):format(fromInventory.id, slot)
+        local toRef = ('%s:%s'):format(toInventory.id, toSlot)
 
-		if activeSlots[fromRef] or activeSlots[toRef] then
-			return { 'cannot_give', count, data.label }
-		end
+        if activeSlots[fromRef] or activeSlots[toRef] then
+            return { 'cannot_give', count, data.label }
+        end
 
-		activeSlots[fromRef] = true
-		activeSlots[toRef] = true
+        activeSlots[fromRef] = true
+        activeSlots[toRef] = true
 
-		local _ <close> = defer(function()
-			activeSlots[fromRef] = nil
-			activeSlots[toRef] = nil
-		end)
+        local _ <close> = defer(function()
+            activeSlots[fromRef] = nil
+            activeSlots[toRef] = nil
+        end)
 
-		if TriggerEventHooks('swapItems', {
-				source = fromInventory.id,
-				fromInventory = fromInventory.id,
-				fromType = fromInventory.type,
-				toInventory = toInventory.id,
-				toType = toInventory.type,
-				count = count,
-				action = 'give',
-				fromSlot = data,
-			}) then
-			---@todo manually call swapItems or something?
-			if Inventory.AddItem(toInventory, item, count, data.metadata, toSlot) then
-				if Inventory.RemoveItem(fromInventory, item, count, data.metadata, slot) then
-					if server.loglevel > 0 then
-						lib.logger(fromInventory.owner, 'giveItem',
-							('"%s" gave %sx %s to "%s"'):format(fromInventory.label, count, data.name, toInventory.label))
-					end
+        if TriggerEventHooks('swapItems', {
+                source = fromInventory.id,
+                fromInventory = fromInventory.id,
+                fromType = fromInventory.type,
+                toInventory = toInventory.id,
+                toType = toInventory.type,
+                count = count,
+                action = 'give',
+                fromSlot = data,
+            }) then
+            ---@todo manually call swapItems or something?
+            if Inventory.AddItem(toInventory, item, count, data.metadata, toSlot) then
+                if Inventory.RemoveItem(fromInventory, item, count, data.metadata, slot) then
+                    if server.loglevel > 0 then
+                        lib.logger(fromInventory.owner, 'giveItem',
+                            ('"%s" gave %sx %s to "%s"'):format(fromInventory.label, count, data.name, toInventory.label))
+                    end
 
-					return
-				else
-					Inventory.RemoveItem(toInventory, item, count, data.metadata, toSlot)
-				end
-			end
-		end
+                    return
+                else
+                    Inventory.RemoveItem(toInventory, item, count, data.metadata, toSlot)
+                end
+            end
+        end
 
-		return { 'cannot_give', count, data.label }
-	end
+        return { 'cannot_give', count, data.label }
+    end
 end
 
 lib.callback.register('ox_inventory:giveItem', giveItem)
 RegisterServerEvent('ox_inventory:giveItem', function(...) giveItem(source, ...) end)
 
 local function updateWeapon(source, action, value, slot, specialAmmo)
-	local inventory = Inventory(source)
+    local inventory = Inventory(source)
 
-	if not inventory then return end
+    if not inventory then return end
 
-	if not action then
-		inventory.weapon = nil
-		return
-	end
+    if not action then
+        inventory.weapon = nil
+        return
+    end
 
-	local type = type(value)
+    local type = type(value)
 
-	if type == 'table' and action == 'component' then
-		local item = inventory.items[value.slot]
+    if type == 'table' and action == 'component' then
+        local item = inventory.items[value.slot]
 
-		if item then
-			if item.metadata.components then
-				for k, v in pairs(item.metadata.components) do
-					if v == value.component then
-						if not Inventory.AddItem(inventory, value.component, 1) then return end
+        if item then
+            if item.metadata.components then
+                for k, v in pairs(item.metadata.components) do
+                    if v == value.component then
+                        if not Inventory.AddItem(inventory, value.component, 1) then return end
 
-						table.remove(item.metadata.components, k)
-						inventory:syncSlotsWithPlayer({
-							{ item = item }
-						}, inventory.weight)
+                        table.remove(item.metadata.components, k)
+                        inventory:syncSlotsWithPlayer({
+                            { item = item }
+                        }, inventory.weight)
 
-						if server.syncInventory then server.syncInventory(inventory) end
+                        if server.syncInventory then server.syncInventory(inventory) end
 
-						return true
-					end
-				end
-			end
-		end
-	else
-		if not slot then slot = inventory.weapon end
-		local weapon = inventory.items[slot]
+                        return true
+                    end
+                end
+            end
+        end
+    else
+        if not slot then slot = inventory.weapon end
+        local weapon = inventory.items[slot]
 
-		if weapon and weapon.metadata then
-			local item = Items(weapon.name)
+        if weapon and weapon.metadata then
+            local item = Items(weapon.name)
 
-			if not item.weapon then
-				inventory.weapon = nil
-				return
-			end
+            if not item.weapon then
+                inventory.weapon = nil
+                return
+            end
 
-			if action == 'load' and weapon.metadata.durability > 0 then
-				local ammo = Items(weapon.name).ammoname
-				local diff = value - (weapon.metadata.ammo or 0)
+            if action == 'load' and weapon.metadata.durability > 0 then
+                local ammo = Items(weapon.name).ammoname
+                local diff = value - (weapon.metadata.ammo or 0)
 
-				if not Inventory.RemoveItem(inventory, ammo, diff, specialAmmo) then return end
+                if not Inventory.RemoveItem(inventory, ammo, diff, specialAmmo) then return end
 
-				weapon.metadata.ammo = value
-				weapon.metadata.specialAmmo = specialAmmo
-				weapon.weight = Inventory.SlotWeight(item, weapon)
-			elseif action == 'throw' then
-				if not Inventory.RemoveItem(inventory, weapon.name, 1, weapon.metadata, weapon.slot) then return end
-			elseif action == 'component' then
-				if type == 'number' then
-					if not Inventory.AddItem(inventory, weapon.metadata.components[value], 1) then return false end
+                weapon.metadata.ammo = value
+                weapon.metadata.specialAmmo = specialAmmo
+                weapon.weight = Inventory.SlotWeight(item, weapon)
+            elseif action == 'throw' then
+                if not Inventory.RemoveItem(inventory, weapon.name, 1, weapon.metadata, weapon.slot) then return end
+            elseif action == 'component' then
+                if type == 'number' then
+                    if not Inventory.AddItem(inventory, weapon.metadata.components[value], 1) then return false end
 
-					table.remove(weapon.metadata.components, value)
-					weapon.weight = Inventory.SlotWeight(item, weapon)
-				elseif type == 'string' then
-					local component = inventory.items[tonumber(value)]
+                    table.remove(weapon.metadata.components, value)
+                    weapon.weight = Inventory.SlotWeight(item, weapon)
+                elseif type == 'string' then
+                    local component = inventory.items[tonumber(value)]
 
-					if not Inventory.RemoveItem(inventory, component.name, 1) then return false end
+                    if not Inventory.RemoveItem(inventory, component.name, 1) then return false end
 
-					table.insert(weapon.metadata.components, component.name)
-					weapon.weight = Inventory.SlotWeight(item, weapon)
-				end
-			elseif action == 'ammo' then
-				if item.hash == `WEAPON_FIREEXTINGUISHER` or item.hash == `WEAPON_PETROLCAN` or item.hash == `WEAPON_HAZARDCAN` or item.hash == `WEAPON_FERTILIZERCAN` then
-					weapon.metadata.durability = math.floor(value)
-					weapon.metadata.ammo = weapon.metadata.durability
-				elseif value < weapon.metadata.ammo then
-					local durability = Items(weapon.name).durability * math.abs((weapon.metadata.ammo or 0.1) - value)
-					weapon.metadata.ammo = value
-					weapon.metadata.durability = weapon.metadata.durability - durability
-					weapon.weight = Inventory.SlotWeight(item, weapon)
-				end
-			elseif action == 'melee' and value > 0 then
-				weapon.metadata.durability = weapon.metadata.durability - ((Items(weapon.name).durability or 1) * value)
-			end
+                    table.insert(weapon.metadata.components, component.name)
+                    weapon.weight = Inventory.SlotWeight(item, weapon)
+                end
+            elseif action == 'ammo' then
+                if item.hash == `WEAPON_FIREEXTINGUISHER` or item.hash == `WEAPON_PETROLCAN` or item.hash == `WEAPON_HAZARDCAN` or item.hash == `WEAPON_FERTILIZERCAN` then
+                    weapon.metadata.durability = math.floor(value)
+                    weapon.metadata.ammo = weapon.metadata.durability
+                elseif value < weapon.metadata.ammo then
+                    local durability = Items(weapon.name).durability * math.abs((weapon.metadata.ammo or 0.1) - value)
+                    weapon.metadata.ammo = value
+                    weapon.metadata.durability = weapon.metadata.durability - durability
+                    weapon.weight = Inventory.SlotWeight(item, weapon)
+                end
+            elseif action == 'melee' and value > 0 then
+                weapon.metadata.durability = weapon.metadata.durability - ((Items(weapon.name).durability or 1) * value)
+            end
 
-			if (weapon.metadata.durability or 0) < 0 then
-				weapon.metadata.durability = 0
-			end
+            if (weapon.metadata.durability or 0) < 0 then
+                weapon.metadata.durability = 0
+            end
 
-			if item.hash == `WEAPON_PETROLCAN` then
-				weapon.weight = Inventory.SlotWeight(item, weapon)
-			end
+            if item.hash == `WEAPON_PETROLCAN` then
+                weapon.weight = Inventory.SlotWeight(item, weapon)
+            end
 
-			if action ~= 'throw' then
-				inventory:syncSlotsWithPlayer({
-					{ item = weapon }
-				}, inventory.weight)
-			end
+            if action ~= 'throw' then
+                inventory:syncSlotsWithPlayer({
+                    { item = weapon }
+                }, inventory.weight)
+            end
 
-			if server.syncInventory then server.syncInventory(inventory) end
+            if server.syncInventory then server.syncInventory(inventory) end
 
-			return true
-		end
-	end
+            return true
+        end
+    end
 end
 
 lib.callback.register('ox_inventory:updateWeapon', updateWeapon)
 
 RegisterNetEvent('ox_inventory:updateWeapon', function(action, value, slot, specialAmmo)
-	updateWeapon(source, action, value, slot, specialAmmo)
+    updateWeapon(source, action, value, slot, specialAmmo)
 end)
 
 lib.callback.register('ox_inventory:removeAmmoFromWeapon', function(source, slot)
-	local inventory = Inventory(source)
+    local inventory = Inventory(source)
 
-	if not inventory then return end
+    if not inventory then return end
 
-	local slotData = inventory.items[slot]
+    local slotData = inventory.items[slot]
 
-	if not slotData or not slotData.metadata.ammo or slotData.metadata.ammo < 1 then return end
+    if not slotData or not slotData.metadata.ammo or slotData.metadata.ammo < 1 then return end
 
-	local item = Items(slotData.name)
+    local item = Items(slotData.name)
 
-	if not item or not item.ammoname then return end
-	local specialAmmo = slotData.metadata.specialAmmo and { type = slotData.metadata.specialAmmo } or nil
+    if not item or not item.ammoname then return end
+    local specialAmmo = slotData.metadata.specialAmmo and { type = slotData.metadata.specialAmmo } or nil
 
 
-	if Inventory.AddItem(inventory, item.ammoname, slotData.metadata.ammo, specialAmmo) then
-		slotData.metadata.ammo = 0
-		slotData.weight = Inventory.SlotWeight(item, slotData)
+    if Inventory.AddItem(inventory, item.ammoname, slotData.metadata.ammo, specialAmmo) then
+        slotData.metadata.ammo = 0
+        slotData.weight = Inventory.SlotWeight(item, slotData)
 
-		inventory:syncSlotsWithPlayer({
-			{ item = slotData }
-		}, inventory.weight)
+        inventory:syncSlotsWithPlayer({
+            { item = slotData }
+        }, inventory.weight)
 
-		if server.syncInventory then server.syncInventory(inventory) end
+        if server.syncInventory then server.syncInventory(inventory) end
 
-		return true
-	end
+        return true
+    end
 end)
 
 local function checkStashProperties(properties)
-	local name = properties.name
-	local slots = properties.slots
-	local maxWeight = properties.maxWeight
-	local coords = properties.coords
+    local name = properties.name
+    local slots = properties.slots
+    local maxWeight = properties.maxWeight
+    local coords = properties.coords
 
-	if type(name) ~= 'string' then
-		error(('received %s for stash name (expected string)'):format(type(name)))
-	end
+    if type(name) ~= 'string' then
+        error(('received %s for stash name (expected string)'):format(type(name)))
+    end
 
-	if type(slots) ~= 'number' then
-		error(('received %s for stash slots (expected number)'):format(type(slots)))
-	end
+    if type(slots) ~= 'number' then
+        error(('received %s for stash slots (expected number)'):format(type(slots)))
+    end
 
-	if type(maxWeight) ~= 'number' then
-		error(('received %s for stash maxWeight (expected number)'):format(type(maxWeight)))
-	end
+    if type(maxWeight) ~= 'number' then
+        error(('received %s for stash maxWeight (expected number)'):format(type(maxWeight)))
+    end
 
-	if coords then
-		local typeof = type(coords)
+    if coords then
+        local typeof = type(coords)
 
-		if typeof ~= 'vector3' then
-			if typeof == 'table' and table.type(coords) ~= 'array' then
-				coords = vec3(coords.x or coords[1], coords.y or coords[2], coords.z or coords[3])
-			else
-				if table.type(coords) == 'array' then
-					for i = 1, #coords do
-						coords[i] = vec3(coords[i].x, coords[i].y, coords[i].z)
-					end
-				else
-					error(('received %s for stash coords (expected vector3 or array of vector3)'):format(typeof))
-				end
-			end
-		end
-	end
+        if typeof ~= 'vector3' then
+            if typeof == 'table' and table.type(coords) ~= 'array' then
+                coords = vec3(coords.x or coords[1], coords.y or coords[2], coords.z or coords[3])
+            else
+                if table.type(coords) == 'array' then
+                    for i = 1, #coords do
+                        coords[i] = vec3(coords[i].x, coords[i].y, coords[i].z)
+                    end
+                else
+                    error(('received %s for stash coords (expected vector3 or array of vector3)'):format(typeof))
+                end
+            end
+        end
+    end
 
-	return name, slots, maxWeight, coords
+    return name, slots, maxWeight, coords
 end
 
 ---@param name string stash identifier when loading from the database
@@ -2700,70 +2700,70 @@ end
 --- groups: { ['police'] = 0 }
 --- ```
 local function registerStash(name, label, slots, maxWeight, owner, groups, coords)
-	name, slots, maxWeight, coords = checkStashProperties({
-		name = name,
-		slots = slots,
-		maxWeight = maxWeight,
-		coords = coords,
-	})
+    name, slots, maxWeight, coords = checkStashProperties({
+        name = name,
+        slots = slots,
+        maxWeight = maxWeight,
+        coords = coords,
+    })
 
-	local curStash = RegisteredStashes[name]
+    local curStash = RegisteredStashes[name]
 
-	if curStash then
-		---@todo creating proper stash classes with inheritence would simplify updating data
-		---i.e. all stashes with the same type share groups, maxweight, slots, dbid, etc.
-		---only label, owner, weight, coords, and items really need to vary
-		for _, stash in pairs(Inventories) do
-			if stash.type == 'stash' and stash.dbId == name then
-				stash.label = label or stash.label
-				stash.owner = (owner and owner ~= true) and stash.owner or owner
-				stash.slots = slots or stash.slots
-				stash.maxWeight = maxWeight or stash.maxWeight
-				stash.groups = groups or stash.groups
-				stash.coords = coords or stash.coords
-			end
-		end
-	end
+    if curStash then
+        ---@todo creating proper stash classes with inheritence would simplify updating data
+        ---i.e. all stashes with the same type share groups, maxweight, slots, dbid, etc.
+        ---only label, owner, weight, coords, and items really need to vary
+        for _, stash in pairs(Inventories) do
+            if stash.type == 'stash' and stash.dbId == name then
+                stash.label = label or stash.label
+                stash.owner = (owner and owner ~= true) and stash.owner or owner
+                stash.slots = slots or stash.slots
+                stash.maxWeight = maxWeight or stash.maxWeight
+                stash.groups = groups or stash.groups
+                stash.coords = coords or stash.coords
+            end
+        end
+    end
 
-	RegisteredStashes[name] = {
-		name = name,
-		label = label,
-		owner = owner,
-		slots = slots,
-		maxWeight = maxWeight,
-		groups = groups,
-		coords = coords
-	}
+    RegisteredStashes[name] = {
+        name = name,
+        label = label,
+        owner = owner,
+        slots = slots,
+        maxWeight = maxWeight,
+        groups = groups,
+        coords = coords
+    }
 end
 
 exports('RegisterStash', registerStash)
 
 ---@param properties TemporaryStashProperties
 function Inventory.CreateTemporaryStash(properties)
-	properties.name = generateInvId('temp')
+    properties.name = generateInvId('temp')
 
-	local name, slots, maxWeight, coords = checkStashProperties(properties)
-	local inventory = Inventory.Create(name, properties.label, 'temp', slots, 0, maxWeight, properties.owner, {},
-		properties.groups)
+    local name, slots, maxWeight, coords = checkStashProperties(properties)
+    local inventory = Inventory.Create(name, properties.label, 'temp', slots, 0, maxWeight, properties.owner, {},
+        properties.groups)
 
-	if not inventory then return end
+    if not inventory then return end
 
-	inventory.items, inventory.weight = generateItems(inventory, 'drop', properties.items)
-	inventory.coords = coords
+    inventory.items, inventory.weight = generateItems(inventory, 'drop', properties.items)
+    inventory.coords = coords
 
-	return inventory.id
+    return inventory.id
 end
 
 exports('CreateTemporaryStash', Inventory.CreateTemporaryStash)
 
 function Inventory.InspectInventory(playerId, invId)
-	local inventory = invId ~= playerId and Inventory(invId)
-	local playerInventory = Inventory(playerId)
+    local inventory = invId ~= playerId and Inventory(invId)
+    local playerInventory = Inventory(playerId)
 
-	if playerInventory and inventory then
-		playerInventory:openInventory(inventory)
-		TriggerClientEvent('ox_inventory:viewInventory', playerId, playerInventory, inventory)
-	end
+    if playerInventory and inventory then
+        playerInventory:openInventory(inventory)
+        TriggerClientEvent('ox_inventory:viewInventory', playerId, playerInventory, inventory)
+    end
 end
 
 exports('InspectInventory', Inventory.InspectInventory)

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -62,11 +62,11 @@ end
 function OxInventory:syncSlotsWithClients(slots, syncOwner)
 	for playerId in pairs(self.openedBy) do
 		if self.id ~= playerId then
-            local target = Inventories[playerId]
+			local target = Inventories[playerId]
 
-            if target then
-			    TriggerClientEvent('ox_inventory:updateSlots', playerId, slots, target.weight)
-            end
+			if target then
+				TriggerClientEvent('ox_inventory:updateSlots', playerId, slots, target.weight)
+			end
 		end
 	end
 
@@ -87,7 +87,7 @@ for _, stash in pairs(lib.load('data.stashes') or {}) do
 		maxWeight = stash.weight,
 		groups = stash.groups or stash.jobs,
 		coords = shared.target and stash.target?.loc or stash.coords,
-        distance = stash.distance or 10
+		distance = stash.distance or 10
 	}
 end
 
@@ -129,10 +129,11 @@ local function loadInventoryData(data, player, ignoreSecurityChecks)
 				entity = NetworkGetEntityFromNetworkId(data.netid)
 
 				if not entity then
-					return shared.info('Failed to load vehicle inventory data (no entity exists with given netid).')
+					return shared.info(
+						'Failed to load vehicle inventory data (no entity exists with given netid).')
 				end
 
-                data.entityId = entity
+				data.entityId = entity
 			else
 				local vehicles = GetAllVehicles()
 
@@ -142,14 +143,15 @@ local function loadInventoryData(data, player, ignoreSecurityChecks)
 
 					if _plate:find(plate) then
 						entity = vehicle
-                        data.entityId = entity
+						data.entityId = entity
 						data.netid = NetworkGetNetworkIdFromEntity(entity)
 						break
 					end
 				end
 
 				if not entity then
-					return shared.info('Failed to load vehicle inventory data (no entity exists with given plate).')
+					return shared.info(
+						'Failed to load vehicle inventory data (no entity exists with given plate).')
 				end
 			end
 
@@ -163,15 +165,16 @@ local function loadInventoryData(data, player, ignoreSecurityChecks)
 
 			local model, class = lib.callback.await('ox_inventory:getVehicleData', source, data.netid)
 			local storage = Vehicles[data.type].models[model] or Vehicles[data.type][class]
-            local dbId
+			local dbId
 
-            if server.getOwnedVehicleId then
-                dbId = server.getOwnedVehicleId(entity)
-            else
-                dbId = data.id:sub(6)
-            end
+			if server.getOwnedVehicleId then
+				dbId = server.getOwnedVehicleId(entity)
+			else
+				dbId = data.id:sub(6)
+			end
 
-            inventory = Inventory.Create(data.id, plate, data.type, storage[1], 0, storage[2], false, nil, nil, dbId)
+			inventory = Inventory.Create(data.id, plate, data.type, storage[1], 0, storage[2], false, nil,
+				nil, dbId)
 		end
 	elseif data.type == 'policeevidence' then
 		inventory = Inventory.Create(data.id, locale('police_evidence'), data.type, 100, 0, 100000, false)
@@ -195,15 +198,16 @@ local function loadInventoryData(data, player, ignoreSecurityChecks)
 			inventory = Inventories[owner and ('%s:%s'):format(stash.name, owner) or stash.name]
 
 			if not inventory then
-				inventory = Inventory.Create(stash.name, stash.label or stash.name, 'stash', stash.slots, 0, stash.maxWeight, owner, nil, stash.groups)
-                inventory.coords = stash.coords
-                inventory.distance = stash.distance
+				inventory = Inventory.Create(stash.name, stash.label or stash.name, 'stash', stash.slots,
+					0, stash.maxWeight, owner, nil, stash.groups)
+				inventory.coords = stash.coords
+				inventory.distance = stash.distance
 			end
 		end
 	end
 
 	if data.netid then
-        inventory.entityId = data.entityId or NetworkGetEntityFromNetworkId(data.netid)
+		inventory.entityId = data.entityId or NetworkGetEntityFromNetworkId(data.netid)
 		inventory.netid = data.netid
 	end
 
@@ -212,14 +216,15 @@ end
 
 setmetatable(Inventory, {
 	__call = function(self, inv, player, ignoreSecurityChecks)
-        if Inventory.Lock then return false end
+		if Inventory.Lock then return false end
 
 		if not inv then
 			return self
 		elseif type(inv) == 'table' then
 			if inv.__index then return inv end
 
-			return not inv.owner and Inventories[inv.id] or loadInventoryData(inv, player, ignoreSecurityChecks)
+			return not inv.owner and Inventories[inv.id] or
+			    loadInventoryData(inv, player, ignoreSecurityChecks)
 		end
 
 		return Inventories[inv] or loadInventoryData({ id = inv }, player, ignoreSecurityChecks)
@@ -264,7 +269,8 @@ function Inventory.GetContainerFromSlot(inv, slotId)
 	local container = Inventory(slotData.metadata.container)
 
 	if not container then
-		container = Inventory.Create(slotData.metadata.container, slotData.label, 'container', slotData.metadata.size[1], 0, slotData.metadata.size[2], false)
+		container = Inventory.Create(slotData.metadata.container, slotData.label, 'container',
+			slotData.metadata.size[1], 0, slotData.metadata.size[2], false)
 	end
 
 	return container
@@ -295,8 +301,8 @@ function Inventory.CloseAll(inv, ignoreId)
 		local playerInv = Inventory(playerId)
 
 		if playerInv and playerId ~= ignoreId then
-            playerInv:closeInventory()
-        end
+			playerInv:closeInventory()
+		end
 	end
 end
 
@@ -385,12 +391,24 @@ function Inventory.SetSlot(inv, item, count, metadata, slot)
 		TriggerClientEvent('ox_inventory:itemNotify', inv.id, { currentSlot, 'ui_removed', currentSlot.count })
 		currentSlot = nil
 	else
-		currentSlot = {name = item.name, label = item.label, weight = item.weight, slot = slot, count = newCount, description = item.description, metadata = metadata, stack = item.stack, close = item.close}
+		currentSlot = {
+			name = item.name,
+			label = item.label,
+			weight = item.weight,
+			slot = slot,
+			count = newCount,
+			description =
+			    item.description,
+			metadata = metadata,
+			stack = item.stack,
+			close = item.close
+		}
 		local slotWeight = Inventory.SlotWeight(item, currentSlot)
 		currentSlot.weight = slotWeight
 		newWeight += slotWeight
 
-		TriggerClientEvent('ox_inventory:itemNotify', inv.id, { currentSlot, count < 0 and 'ui_removed' or 'ui_added', math.abs(count) })
+		TriggerClientEvent('ox_inventory:itemNotify', inv.id,
+			{ currentSlot, count < 0 and 'ui_removed' or 'ui_added', math.abs(count) })
 	end
 
 	inv.weight = newWeight
@@ -403,16 +421,16 @@ end
 local Items = require 'modules.items.server'
 
 CreateThread(function()
-    Inventory.accounts = server.accounts
-    TriggerEvent('ox_inventory:loadInventory', Inventory)
+	Inventory.accounts = server.accounts
+	TriggerEvent('ox_inventory:loadInventory', Inventory)
 end)
 
 function Inventory.GetAccountItemCounts(inv)
-    inv = Inventory(inv)
+	inv = Inventory(inv)
 
-    if not inv then return end
+	if not inv then return end
 
-    local accounts = table.clone(server.accounts)
+	local accounts = table.clone(server.accounts)
 
 	for _, v in pairs(inv.items) do
 		if accounts[v.name] then
@@ -420,7 +438,7 @@ function Inventory.GetAccountItemCounts(inv)
 		end
 	end
 
-    return accounts
+	return accounts
 end
 
 ---@param item table
@@ -438,9 +456,9 @@ function Inventory.SlotWeight(item, slot, ignoreCount)
 		end
 	end
 
-    if item.hash == `WEAPON_PETROLCAN` then
-        slot.metadata.weight = 15000 * (slot.metadata.ammo / 100)
-    end
+	if item.hash == `WEAPON_PETROLCAN` then
+		slot.metadata.weight = 15000 * (slot.metadata.ammo / 100)
+	end
 
 	if slot.metadata.components then
 		for i = #slot.metadata.components, 1, -1 do
@@ -478,9 +496,9 @@ local function hasActiveInventory(playerId, owner)
 	local activePlayer = activeIdentifiers[owner]
 
 	if activePlayer then
-        if activePlayer == playerId then
-            error('attempted to load active player\'s inventory a secondary time', 0)
-        end
+		if activePlayer == playerId then
+			error('attempted to load active player\'s inventory a secondary time', 0)
+		end
 
 		local inventory = Inventory(activePlayer)
 
@@ -490,7 +508,7 @@ local function hasActiveInventory(playerId, owner)
 			if endpoint then
 				DropPlayer(playerId, ("Character identifier '%s' is already active."):format(owner))
 
-                -- Supposedly still getting stuck? Print info and hope somebody reports back (lol)
+				-- Supposedly still getting stuck? Print info and hope somebody reports back (lol)
 				print(('kicked player.%s (charid is already in use)'):format(playerId), json.encode({
 					oldId = activePlayer,
 					newId = playerId,
@@ -498,10 +516,11 @@ local function hasActiveInventory(playerId, owner)
 					endpoint = endpoint,
 					playerName = GetPlayerName(activePlayer),
 					fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
-					license = GetPlayerIdentifierByType(activePlayer, 'license2') or GetPlayerIdentifierByType(activePlayer, 'license'),
+					license = GetPlayerIdentifierByType(activePlayer, 'license2') or
+					    GetPlayerIdentifierByType(activePlayer, 'license'),
 				}, {
 					indent = true,
-                    sort_keys = true
+					sort_keys = true
 				}))
 
 				return true
@@ -520,36 +539,37 @@ end
 ---Manually clear an inventory state tied to the given identifier.
 ---Temporary workaround until somebody actually gives me info.
 RegisterCommand('clearActiveIdentifier', function(source, args)
-    ---Server console only.
-    if source ~= 0 then return end
+	---Server console only.
+	if source ~= 0 then return end
 
 	local activePlayer = activeIdentifiers[args[1]] or activeIdentifiers[tonumber(args[1])]
-    local inventory = activePlayer and Inventory(activePlayer)
+	local inventory = activePlayer and Inventory(activePlayer)
 
-    if not inventory then return end
+	if not inventory then return end
 
-    local endpoint = GetPlayerEndpoint(activePlayer)
+	local endpoint = GetPlayerEndpoint(activePlayer)
 
-    if endpoint then
-        DropPlayer(activePlayer, 'Kicked')
+	if endpoint then
+		DropPlayer(activePlayer, 'Kicked')
 
-        -- Supposedly still getting stuck? Print info and hope somebody reports back (lol)
-        print(('kicked player.%s (clearActiveIdentifier)'):format(activePlayer), json.encode({
-            oldId = activePlayer,
-            charid = inventory.owner,
-            endpoint = endpoint,
-            playerName = GetPlayerName(activePlayer),
-            fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
-            license = GetPlayerIdentifierByType(activePlayer, 'license2') or GetPlayerIdentifierByType(activePlayer, 'license'),
-        }, {
-            indent = true,
-            sort_keys = true
-        }))
-    end
+		-- Supposedly still getting stuck? Print info and hope somebody reports back (lol)
+		print(('kicked player.%s (clearActiveIdentifier)'):format(activePlayer), json.encode({
+			oldId = activePlayer,
+			charid = inventory.owner,
+			endpoint = endpoint,
+			playerName = GetPlayerName(activePlayer),
+			fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
+			license = GetPlayerIdentifierByType(activePlayer, 'license2') or
+			    GetPlayerIdentifierByType(activePlayer, 'license'),
+		}, {
+			indent = true,
+			sort_keys = true
+		}))
+	end
 
-    Inventory.CloseAll(inventory)
-    db.savePlayer(inventory.owner, json.encode(inventory:minimal()))
-    Inventory.Remove(inventory)
+	Inventory.CloseAll(inventory)
+	db.savePlayer(inventory.owner, json.encode(inventory:minimal()))
+	Inventory.Remove(inventory)
 end, true)
 
 ---@param id string|number
@@ -583,7 +603,7 @@ function Inventory.Create(id, label, invType, slots, weight, maxWeight, owner, i
 		time = os.time(),
 		groups = groups,
 		openedBy = {},
-        dbId = dbId
+		dbId = dbId
 	}
 
 	if invType == 'drop' or invType == 'temp' or invType == 'dumpster' then
@@ -616,28 +636,28 @@ function Inventory.Remove(inv)
 
 	if not inv then return end
 
-    if inv.type == 'drop' then
-        TriggerClientEvent('ox_inventory:removeDrop', -1, inv.id)
-        Inventory.Drops[inv.id] = nil
-    elseif inv.player then
-        activeIdentifiers[inv.owner] = nil
-    end
+	if inv.type == 'drop' then
+		TriggerClientEvent('ox_inventory:removeDrop', -1, inv.id)
+		Inventory.Drops[inv.id] = nil
+	elseif inv.player then
+		activeIdentifiers[inv.owner] = nil
+	end
 
-    for playerId in pairs(inv.openedBy) do
-        if inv.id ~= playerId then
-            local target = Inventories[playerId]
+	for playerId in pairs(inv.openedBy) do
+		if inv.id ~= playerId then
+			local target = Inventories[playerId]
 
-            if target then
-                target:closeInventory()
-            end
-        end
-    end
+			if target then
+				target:closeInventory()
+			end
+		end
+	end
 
-    if not inv.datastore and inv.changed then
-        Inventory.Save(inv)
-    end
+	if not inv.datastore and inv.changed then
+		Inventory.Save(inv)
+	end
 
-    Inventories[inv.id] = nil
+	Inventories[inv.id] = nil
 end
 
 exports('RemoveInventory', Inventory.Remove)
@@ -685,32 +705,32 @@ function Inventory.Save(inv)
 
 	if not inv or inv.datastore then return end
 
-    local buffer, n = {}, 0
+	local buffer, n = {}, 0
 
-    for k, v in pairs(inv.items) do
-        if not Items.UpdateDurability(inv, v, Items(v.name), nil, os.time()) then
-            n += 1
-            buffer[n] = {
-                name = v.name,
-                count = v.count,
-                slot = k,
-                metadata = next(v.metadata) and v.metadata or nil
-            }
-        end
-    end
+	for k, v in pairs(inv.items) do
+		if not Items.UpdateDurability(inv, v, Items(v.name), nil, os.time()) then
+			n += 1
+			buffer[n] = {
+				name = v.name,
+				count = v.count,
+				slot = k,
+				metadata = next(v.metadata) and v.metadata or nil
+			}
+		end
+	end
 
-    local data = next(buffer) and json.encode(buffer) or nil
-    inv.changed = false
+	local data = next(buffer) and json.encode(buffer) or nil
+	inv.changed = false
 
-    if inv.player then
-        return shared.framework ~= 'esx' and db.savePlayer(inv.owner, data)
-    elseif inv.type == 'trunk' then
-        return db.saveTrunk(inv.dbId, data)
-    elseif inv.type == 'glovebox' then
-        return db.saveGlovebox(inv.dbId, data)
-    end
+	if inv.player then
+		return shared.framework ~= 'esx' and db.savePlayer(inv.owner, data)
+	elseif inv.type == 'trunk' then
+		return db.saveTrunk(inv.dbId, data)
+	elseif inv.type == 'glovebox' then
+		return db.saveGlovebox(inv.dbId, data)
+	end
 
-    return db.saveStash(inv.owner, inv.dbId, data)
+	return db.saveStash(inv.owner, inv.dbId, data)
 end
 
 ---@alias RandomLoot { [1]: string, [2]: number, [3]: number, [4]?: number }
@@ -720,51 +740,51 @@ end
 ---@param size number
 ---@return RandomLoot
 local function randomItem(loot, items, size)
-    local itemIndex = math.random(1, size)
-    local selectedItem = nil
+	local itemIndex = math.random(1, size)
+	local selectedItem = nil
 
-    for _ = 1, size do
-        selectedItem = loot[itemIndex]
-        local found = false
+	for _ = 1, size do
+		selectedItem = loot[itemIndex]
+		local found = false
 
-        for i = 1, #items do
-            if items[i][1] == selectedItem[1] then
-                found = true
-                break
-            end
-        end
+		for i = 1, #items do
+			if items[i][1] == selectedItem[1] then
+				found = true
+				break
+			end
+		end
 
-        if not found then break end
+		if not found then break end
 
-        itemIndex = ((itemIndex - 1) % size) + 1
-    end
+		itemIndex = ((itemIndex - 1) % size) + 1
+	end
 
-    return selectedItem
+	return selectedItem
 end
 
 ---@param loot RandomLoot[]
 ---@return RandomLoot[]
 local function randomLoot(loot)
-    ---@type RandomLoot[]
-    local items = {}
-    local size = #loot
-    local itemCount = math.random(0, 3)
+	---@type RandomLoot[]
+	local items = {}
+	local size = #loot
+	local itemCount = math.random(0, 3)
 
-    for _ = 1, itemCount do
-        if #items >= size then break end
+	for _ = 1, itemCount do
+		if #items >= size then break end
 
-        local item = randomItem(loot, items, size)
+		local item = randomItem(loot, items, size)
 
-        if item and math.random(1, 100) <= (item[4] or 80) then
-            local count = math.random(item[2], item[3])
+		if item and math.random(1, 100) <= (item[4] or 80) then
+			local count = math.random(item[2], item[3])
 
-            if count > 0 then
-                items[#items + 1] = { item[1], count }
-            end
-        end
-    end
+			if count > 0 then
+				items[#items + 1] = { item[1], count }
+			end
+		end
+	end
 
-    return items
+	return items
 end
 
 ---@param inv inventory
@@ -792,9 +812,20 @@ local function generateItems(inv, invType, items)
 			warn('unable to generate', v[1], 'item does not exist')
 		else
 			local metadata, count = Items.Metadata(inv, item, v[3] or {}, v[2])
-			local weight = Inventory.SlotWeight(item, {count=count, metadata=metadata})
+			local weight = Inventory.SlotWeight(item, { count = count, metadata = metadata })
 			totalWeight = totalWeight + weight
-			returnData[i] = {name = item.name, label = item.label, weight = weight, slot = i, count = count, description = item.description, metadata = metadata, stack = item.stack, close = item.close}
+			returnData[i] = {
+				name = item.name,
+				label = item.label,
+				weight = weight,
+				slot = i,
+				count = count,
+				description =
+				    item.description,
+				metadata = metadata,
+				stack = item.stack,
+				close = item.close
+			}
 		end
 	end
 
@@ -805,20 +836,20 @@ end
 ---@param invType string
 ---@param owner string | number | boolean
 function Inventory.Load(id, invType, owner)
-    if not invType then return end
+	if not invType then return end
 
 	local result
 
-    if invType == 'trunk' or invType == 'glovebox' then
-        result = id and (invType == 'trunk' and db.loadTrunk(id) or db.loadGlovebox(id))
+	if invType == 'trunk' or invType == 'glovebox' then
+		result = id and (invType == 'trunk' and db.loadTrunk(id) or db.loadGlovebox(id))
 
-        if not result then
-            if server.randomloot then
-                return generateItems(id, 'vehicle')
-            end
-        else
-            result = result[invType]
-        end
+		if not result then
+			if server.randomloot then
+				return generateItems(id, 'vehicle')
+			end
+		else
+			result = result[invType]
+		end
 	elseif invType == 'dumpster' then
 		if server.randomloot then
 			return generateItems(id, invType)
@@ -842,7 +873,19 @@ function Inventory.Load(id, invType, owner)
 				v.metadata = Items.CheckMetadata(v.metadata or {}, item, v.name, ostime)
 				local slotWeight = Inventory.SlotWeight(item, v)
 				weight += slotWeight
-				returnData[v.slot] = {name = item.name, label = item.label, weight = slotWeight, slot = v.slot, count = v.count, description = item.description, metadata = v.metadata, stack = item.stack, close = item.close}
+				returnData[v.slot] = {
+					name = item.name,
+					label = item.label,
+					weight = slotWeight,
+					slot =
+					    v.slot,
+					count = v.count,
+					description = item.description,
+					metadata = v.metadata,
+					stack =
+					    item.stack,
+					close = item.close
+				}
 			end
 		end
 	end
@@ -877,17 +920,20 @@ function Inventory.GetItem(inv, item, metadata, returnsCount)
 
 			for _, v in pairs(inv.items) do
 				if v.name == item.name and (not metadata or table.contains(v.metadata, metadata)) and not Items.UpdateDurability(inv, v, item, nil, ostime) then
-                    count += v.count
+					count += v.count
 				end
 			end
 		end
 
-		if returnsCount then return count else
+		if returnsCount then
+			return count
+		else
 			item.count = count
 			return item
 		end
 	end
 end
+
 exports('GetItem', Inventory.GetItem)
 
 ---@param fromInventory any
@@ -906,6 +952,7 @@ function Inventory.SwapSlots(fromInventory, toInventory, slot1, slot2)
 
 	return fromSlot, toSlot
 end
+
 exports('SwapSlots', Inventory.SwapSlots)
 
 function Inventory.ContainerWeight(container, metaWeight, playerInventory)
@@ -945,6 +992,7 @@ function Inventory.SetItem(inv, item, count, metadata)
 		return Inventory.RemoveItem(inv, item.name, itemCount, metadata)
 	end
 end
+
 exports('SetItem', Inventory.SetItem)
 
 ---@param inv inventory
@@ -961,6 +1009,7 @@ function Inventory.GetCurrentWeapon(inv)
 		inv.weapon = nil
 	end
 end
+
 exports('GetCurrentWeapon', Inventory.GetCurrentWeapon)
 
 ---@param inv inventory
@@ -973,9 +1022,10 @@ function Inventory.GetSlot(inv, slotId)
 	local slot = inv and inv.items?[slotId]
 
 	if slot and not Items.UpdateDurability(inv, slot, Items(slot.name), nil, os.time()) then
-        return slot
+		return slot
 	end
 end
+
 exports('GetSlot', Inventory.GetSlot)
 
 ---@param inv inventory
@@ -989,12 +1039,13 @@ function Inventory.SetDurability(inv, slotId, durability)
 
 	if not slot then return end
 
-    Items.UpdateDurability(inv, slot, Items(slot.name), durability)
+	Items.UpdateDurability(inv, slot, Items(slot.name), durability)
 
-    if inv.player and server.syncInventory then
-        server.syncInventory(inv)
-    end
+	if inv.player and server.syncInventory then
+		server.syncInventory(inv)
+	end
 end
+
 exports('SetDurability', Inventory.SetDurability)
 
 local Utils = require 'modules.utils.server'
@@ -1010,40 +1061,48 @@ function Inventory.SetMetadata(inv, slotId, metadata)
 
 	if not slot then return end
 
-    local item = Items(slot.name)
-    local imageurl = slot.metadata.imageurl
-    slot.metadata = type(metadata) == 'table' and metadata or { type = metadata or nil }
-    inv.changed = true
+	local item = Items(slot.name)
+	local imageurl = slot.metadata.imageurl
+	slot.metadata = type(metadata) == 'table' and metadata or { type = metadata or nil }
+	inv.changed = true
 
-    if metadata.weight then
-        inv.weight -= slot.weight
-        slot.weight = Inventory.SlotWeight(item, slot)
-        inv.weight += slot.weight
-    end
+	if metadata.weight then
+		inv.weight -= slot.weight
+		slot.weight = Inventory.SlotWeight(item, slot)
+		inv.weight += slot.weight
+	end
 
-    if metadata.durability ~= slot.metadata.durability then
-        Items.UpdateDurability(inv, slot, item, metadata.durability)
-    else
-        inv:syncSlotsWithClients({
-            {
-                item = slot,
-                inventory = inv.id
-            }
-        }, true)
-    end
+	if metadata.durability ~= slot.metadata.durability then
+		Items.UpdateDurability(inv, slot, item, metadata.durability)
+	else
+		inv:syncSlotsWithClients({
+			{
+				item = slot,
+				inventory = inv.id
+			}
+		}, true)
+	end
 
-    if inv.player and server.syncInventory then
-        server.syncInventory(inv)
-    end
+	if inv.player and server.syncInventory then
+		server.syncInventory(inv)
+	end
 
-    if metadata.imageurl ~= imageurl and Utils.IsValidImageUrl then
-        if Utils.IsValidImageUrl(metadata.imageurl) then
-            Utils.DiscordEmbed('Valid image URL', ('Updated item "%s" (%s) with valid url in "%s".\n%s\nid: %s\nowner: %s'):format(metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id, inv.owner, metadata.imageurl), metadata.imageurl, 65280)
-        else
-            Utils.DiscordEmbed('Invalid image URL', ('Updated item "%s" (%s) with invalid url in "%s".\n%s\nid: %s\nowner: %s'):format(metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id, inv.owner, metadata.imageurl), metadata.imageurl, 16711680)
-            metadata.imageurl = nil
-        end
-    end
+	if metadata.imageurl ~= imageurl and Utils.IsValidImageUrl then
+		if Utils.IsValidImageUrl(metadata.imageurl) then
+			Utils.DiscordEmbed('Valid image URL',
+				('Updated item "%s" (%s) with valid url in "%s".\n%s\nid: %s\nowner: %s'):format(
+					metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id,
+					inv.owner,
+					metadata.imageurl), metadata.imageurl, 65280)
+		else
+			Utils.DiscordEmbed('Invalid image URL',
+				('Updated item "%s" (%s) with invalid url in "%s".\n%s\nid: %s\nowner: %s'):format(
+					metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id,
+					inv.owner,
+					metadata.imageurl), metadata.imageurl, 16711680)
+			metadata.imageurl = nil
+		end
+	end
 end
 
 exports('SetMetadata', Inventory.SetMetadata)
@@ -1060,13 +1119,14 @@ function Inventory.SetSlotCount(inv, slots)
 	inv.slots = slots
 
 	if inv.player then
-        TriggerClientEvent('ox_inventory:refreshSlotCount', inv.id, {inventoryId = inv.id, slots = inv.slots})
-    end
+		TriggerClientEvent('ox_inventory:refreshSlotCount', inv.id, { inventoryId = inv.id, slots = inv.slots })
+	end
 
-    for playerId in pairs(inv.openedBy) do
-        if playerId ~= inv.id then
-            TriggerClientEvent('ox_inventory:refreshSlotCount', playerId, {inventoryId = inv.id, slots = inv.slots})
-        end
+	for playerId in pairs(inv.openedBy) do
+		if playerId ~= inv.id then
+			TriggerClientEvent('ox_inventory:refreshSlotCount', playerId,
+				{ inventoryId = inv.id, slots = inv.slots })
+		end
 	end
 end
 
@@ -1082,14 +1142,16 @@ function Inventory.SetMaxWeight(inv, maxWeight)
 
 	inv.maxWeight = maxWeight
 
-    if inv.player then
-        TriggerClientEvent('ox_inventory:refreshMaxWeight', inv.id, {inventoryId = inv.id, maxWeight = inv.maxWeight})
-    end
+	if inv.player then
+		TriggerClientEvent('ox_inventory:refreshMaxWeight', inv.id,
+			{ inventoryId = inv.id, maxWeight = inv.maxWeight })
+	end
 
-    for playerId in pairs(inv.openedBy) do
-        if playerId ~= inv.id then
-            TriggerClientEvent('ox_inventory:refreshMaxWeight', playerId, {inventoryId = inv.id, maxWeight = inv.maxWeight})
-        end
+	for playerId in pairs(inv.openedBy) do
+		if playerId ~= inv.id then
+			TriggerClientEvent('ox_inventory:refreshMaxWeight', playerId,
+				{ inventoryId = inv.id, maxWeight = inv.maxWeight })
+		end
 	end
 end
 
@@ -1149,7 +1211,8 @@ function Inventory.AddItem(inv, item, count, metadata, slot, cb)
 				end
 
 				count -= 1
-				slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
+				slotMetadata, slotCount = Items.Metadata(inv.id, item,
+					metadata and table.clone(metadata) or {}, count)
 			elseif not toSlot and not slotData then
 				toSlot = i
 			end
@@ -1178,7 +1241,8 @@ function Inventory.AddItem(inv, item, count, metadata, slot, cb)
 		}, true)
 
 		if invokingResource then
-			lib.logger(inv.owner, 'addItem', ('"%s" added %sx %s to "%s"'):format(invokingResource, count, item.name, inv.label))
+			lib.logger(inv.owner, 'addItem',
+				('"%s" added %sx %s to "%s"'):format(invokingResource, count, item.name, inv.label))
 		end
 
 		success = true
@@ -1200,7 +1264,8 @@ function Inventory.AddItem(inv, item, count, metadata, slot, cb)
 		inv:syncSlotsWithClients(toSlot, true)
 
 		if invokingResource then
-			lib.logger(inv.owner, 'addItem', ('"%s" added %sx %s to "%s"'):format(invokingResource, added, item.name, inv.label))
+			lib.logger(inv.owner, 'addItem',
+				('"%s" added %sx %s to "%s"'):format(invokingResource, added, item.name, inv.label))
 		end
 
 		for i = 1, #toSlot do
@@ -1232,7 +1297,7 @@ function Inventory.Search(inv, search, items, metadata)
 			inv = inv.items
 
 			if search == 'slots' then search = 1 elseif search == 'count' then search = 2 end
-			if type(items) == 'string' then items = {items} end
+			if type(items) == 'string' then items = { items } end
 
 			metadata = assertMetadata(metadata)
 			local itemCount = #items
@@ -1254,7 +1319,7 @@ function Inventory.Search(inv, search, items, metadata)
 
 						if not metadata or table.contains(v.metadata, metadata) then
 							if search == 1 then
-								returnData[item][#returnData[item]+1] = inv[v.slot]
+								returnData[item][#returnData[item] + 1] = inv[v.slot]
 							elseif search == 2 then
 								returnData[item] += v.count
 							end
@@ -1269,6 +1334,7 @@ function Inventory.Search(inv, search, items, metadata)
 
 	return false
 end
+
 exports('Search', Inventory.Search)
 
 ---@param inv inventory
@@ -1302,6 +1368,7 @@ function Inventory.GetItemSlots(inv, item, metadata, strict)
 
 	return slots, totalCount, emptySlots
 end
+
 exports('GetItemSlots', Inventory.GetItemSlots)
 
 ---@param inv inventory
@@ -1342,32 +1409,36 @@ function Inventory.RemoveItem(inv, item, count, metadata, slot, ignoreTotal, str
 	if slot and itemSlots[slot] then
 		removed = count
 		Inventory.SetSlot(inv, item, -count, inv.items[slot].metadata, slot)
-		slots[#slots+1] = inv.items[slot] or slot
+		slots[#slots + 1] = inv.items[slot] or slot
 	elseif itemSlots and totalCount > 0 then
 		for k, v in pairs(itemSlots) do
 			if removed < total then
 				if v == count then
-					TriggerClientEvent('ox_inventory:itemNotify', inv.id, { inv.items[k], 'ui_removed', v })
+					TriggerClientEvent('ox_inventory:itemNotify', inv.id,
+						{ inv.items[k], 'ui_removed', v })
 
 					removed = total
 					inv.weight -= inv.items[k].weight
 					inv.items[k] = nil
-					slots[#slots+1] = inv.items[k] or k
+					slots[#slots + 1] = inv.items[k] or k
 				elseif v > count then
 					Inventory.SetSlot(inv, item, -count, inv.items[k].metadata, k)
-					slots[#slots+1] = inv.items[k] or k
+					slots[#slots + 1] = inv.items[k] or k
 					removed = total
 					count = v - count
 				else
-					TriggerClientEvent('ox_inventory:itemNotify', inv.id, { inv.items[k], 'ui_removed', v })
+					TriggerClientEvent('ox_inventory:itemNotify', inv.id,
+						{ inv.items[k], 'ui_removed', v })
 
 					removed = removed + v
 					count = count - v
 					inv.weight -= inv.items[k].weight
 					inv.items[k] = nil
-					slots[#slots+1] = k
+					slots[#slots + 1] = k
 				end
-			else break end
+			else
+				break
+			end
 		end
 	end
 
@@ -1381,7 +1452,7 @@ function Inventory.RemoveItem(inv, item, count, metadata, slot, ignoreTotal, str
 		local array = table.create(#slots, 0)
 
 		for k, v in pairs(slots) do
-			array[k] = {item = type(v) == 'number' and { slot = v } or v, inventory = inv.id}
+			array[k] = { item = type(v) == 'number' and { slot = v } or v, inventory = inv.id }
 		end
 
 		inv:syncSlotsWithClients(array, true)
@@ -1389,7 +1460,8 @@ function Inventory.RemoveItem(inv, item, count, metadata, slot, ignoreTotal, str
 		local invokingResource = server.loglevel > 1 and GetInvokingResource()
 
 		if invokingResource then
-			lib.logger(inv.owner, 'removeItem', ('"%s" removed %sx %s from "%s"'):format(invokingResource, removed, item.name, inv.label))
+			lib.logger(inv.owner, 'removeItem',
+				('"%s" removed %sx %s from "%s"'):format(invokingResource, removed, item.name, inv.label))
 		end
 
 		return true
@@ -1397,6 +1469,7 @@ function Inventory.RemoveItem(inv, item, count, metadata, slot, ignoreTotal, str
 
 	return false, 'not_enough_items'
 end
+
 exports('RemoveItem', Inventory.RemoveItem)
 
 ---@param inv inventory
@@ -1410,7 +1483,8 @@ function Inventory.CanCarryItem(inv, item, count, metadata)
 		inv = Inventory(inv) --[[@as OxInventory]]
 
 		if inv then
-			local itemSlots, _, emptySlots = Inventory.GetItemSlots(inv, item, type(metadata) == 'table' and metadata or { type = metadata or nil })
+			local itemSlots, _, emptySlots = Inventory.GetItemSlots(inv, item,
+				type(metadata) == 'table' and metadata or { type = metadata or nil })
 
 			if not itemSlots then return end
 
@@ -1432,18 +1506,19 @@ function Inventory.CanCarryItem(inv, item, count, metadata)
 		end
 	end
 end
+
 exports('CanCarryItem', Inventory.CanCarryItem)
 
 ---@param inv inventory
 ---@param item table | string
 function Inventory.CanCarryAmount(inv, item)
-    if type(item) ~= 'table' then item = Items(item) end
+	if type(item) ~= 'table' then item = Items(item) end
 	inv = Inventory(inv) --[[@as OxInventory]]
 
-    if inv and item then
+	if inv and item then
 		local availableWeight = inv.maxWeight - inv.weight
 		return math.floor(availableWeight / item.weight)
-    end
+	end
 end
 
 exports('CanCarryAmount', Inventory.CanCarryAmount)
@@ -1459,6 +1534,7 @@ function Inventory.CanCarryWeight(inv, weight)
 	local canHold = availableWeight >= weight
 	return canHold, availableWeight
 end
+
 exports('CanCarryWeight', Inventory.CanCarryWeight)
 
 ---@param inv inventory
@@ -1480,6 +1556,7 @@ function Inventory.CanSwapItem(inv, firstItem, firstItemCount, testItem, testIte
 		return weightWithTest <= inv.maxWeight
 	end
 end
+
 exports('CanSwapItem', Inventory.CanSwapItem)
 
 ---Mostly for internal use, but deprecated.
@@ -1507,7 +1584,8 @@ end
 
 local function CustomDrop(prefix, items, coords, slots, maxWeight, instance, model)
 	local dropId = generateInvId()
-	local inventory = Inventory.Create(dropId, ('%s %s'):format(prefix, dropId:gsub('%D', '')), 'drop', slots or shared.dropslots, 0, maxWeight or shared.dropweight, false, {})
+	local inventory = Inventory.Create(dropId, ('%s %s'):format(prefix, dropId:gsub('%D', '')), 'drop',
+		slots or shared.dropslots, 0, maxWeight or shared.dropweight, false, {})
 
 	if not inventory then return end
 
@@ -1521,7 +1599,7 @@ local function CustomDrop(prefix, items, coords, slots, maxWeight, instance, mod
 
 	TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId])
 
-    return dropId
+	return dropId
 end
 
 AddEventHandler('ox_inventory:customDrop', CustomDrop)
@@ -1533,12 +1611,14 @@ exports('CreateDropFromPlayer', function(playerId)
 	if not playerInventory or not next(playerInventory.items) then return end
 
 	local dropId = generateInvId()
-	local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop', playerInventory.slots, playerInventory.weight, playerInventory.maxWeight, false, table.clone(playerInventory.items))
+	local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop',
+		playerInventory.slots, playerInventory.weight, playerInventory.maxWeight, false,
+		table.clone(playerInventory.items))
 
 	if not inventory then return end
 
 	local coords = GetEntityCoords(GetPlayerPed(playerId))
-	inventory.coords = vec3(coords.x, coords.y, coords.z-0.2)
+	inventory.coords = vec3(coords.x, coords.y, coords.z - 0.2)
 	Inventory.Drops[dropId] = {
 		coords = inventory.coords,
 		instance = Player(playerId).state.instance
@@ -1566,38 +1646,40 @@ local TriggerEventHooks = require 'modules.hooks.server'
 ---@param fromData SlotWithItem?
 ---@param data SwapSlotData
 local function dropItem(source, playerInventory, fromData, data)
-    if not fromData then return end
+	if not fromData then return end
 
 	local toData = table.clone(fromData)
 	toData.slot = data.toSlot
 	toData.count = data.count
 	toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
 
-    if toData.weight > shared.dropweight then return end
+	if toData.weight > shared.dropweight then return end
 
-    local dropId = generateInvId('drop')
+	local dropId = generateInvId('drop')
 
 	if not TriggerEventHooks('swapItems', {
-		source = source,
-		fromInventory = playerInventory.id,
-		fromSlot = fromData,
-		fromType = playerInventory.type,
-		toInventory = 'newdrop',
-		toSlot = data.toSlot,
-		toType = 'drop',
-		count = data.count,
-        action = 'move',
-        dropId = dropId,
-	}) then return end
+		    source = source,
+		    fromInventory = playerInventory.id,
+		    fromSlot = fromData,
+		    fromType = playerInventory.type,
+		    toInventory = 'newdrop',
+		    toSlot = data.toSlot,
+		    toType = 'drop',
+		    count = data.count,
+		    action = 'move',
+		    dropId = dropId,
+	    }) then
+		return
+	end
 
-    fromData.count -= data.count
-    fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
+	fromData.count -= data.count
+	fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
 
-    if fromData.count < 1 then
-        fromData = nil
-    else
-        toData.metadata = table.clone(toData.metadata)
-    end
+	if fromData.count < 1 then
+		fromData = nil
+	else
+		toData.metadata = table.clone(toData.metadata)
+	end
 
 	local slot = data.fromSlot
 	playerInventory.weight -= toData.weight
@@ -1607,18 +1689,22 @@ local function dropItem(source, playerInventory, fromData, data)
 		playerInventory.weapon = nil
 	end
 
-	local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop', shared.dropslots, toData.weight, shared.dropweight, false, {[data.toSlot] = toData})
+	local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop', shared.dropslots,
+		toData.weight, shared.dropweight, false, { [data.toSlot] = toData })
 
 	if not inventory then return end
 
 	inventory.coords = data.coords
-	Inventory.Drops[dropId] = {coords = inventory.coords, instance = data.instance}
+	Inventory.Drops[dropId] = { coords = inventory.coords, instance = data.instance }
 	playerInventory.changed = true
 
-	TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId], playerInventory.open and source, slot)
+	TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId],
+		playerInventory.open and source, slot)
 
 	if server.loglevel > 0 then
-		lib.logger(playerInventory.owner, 'swapSlots', ('%sx %s transferred from "%s" to "%s"'):format(data.count, toData.name, playerInventory.label, dropId))
+		lib.logger(playerInventory.owner, 'swapSlots',
+			('%sx %s transferred from "%s" to "%s"'):format(data.count, toData.name, playerInventory.label,
+				dropId))
 	end
 
 	if server.syncInventory then server.syncInventory(playerInventory) end
@@ -1653,7 +1739,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 		return
 	end
 
-    if data.toType == 'inspect' or data.fromType == 'inspect' then return end
+	if data.toType == 'inspect' or data.fromType == 'inspect' then return end
 
 	local fromRef = ('%s:%s'):format(fromInventory.id, data.fromSlot)
 	local toRef = ('%s:%s'):format(toInventory.id, data.toSlot)
@@ -1708,19 +1794,20 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 			}
 		end
 
-        if data.count > fromData.count then
-            data.count = fromData.count
-        end
+		if data.count > fromData.count then
+			data.count = fromData.count
+		end
 
-        if data.toType == 'newdrop' then
-            return dropItem(source, playerInventory, fromData, data)
-        end
+		if data.toType == 'newdrop' then
+			return dropItem(source, playerInventory, fromData, data)
+		end
 
 		if fromData then
-            if fromData.metadata.container and toInventory.type == 'container' then return false end
-            if toData and toData.metadata.container and fromInventory.type == 'container' then return false end
+			if fromData.metadata.container and toInventory.type == 'container' then return false end
+			if toData and toData.metadata.container and fromInventory.type == 'container' then return false end
 
-			local container, containerItem = (not sameInventory and playerInventory.containerSlot) and (fromInventory.type == 'container' and fromInventory or toInventory)
+			local container, containerItem = (not sameInventory and playerInventory.containerSlot) and
+			    (fromInventory.type == 'container' and fromInventory or toInventory)
 
 			if container then
 				containerItem = playerInventory.items[playerInventory.containerSlot]
@@ -1739,8 +1826,10 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 			if toData and ((toData.name ~= fromData.name) or not toData.stack or (not table.matches(toData.metadata, fromData.metadata))) then
 				-- Swap items
-				local toWeight = not sameInventory and (toInventory.weight - toData.weight + fromData.weight) or 0
-				local fromWeight = not sameInventory and (fromInventory.weight + toData.weight - fromData.weight) or 0
+				local toWeight = not sameInventory and
+				    (toInventory.weight - toData.weight + fromData.weight) or 0
+				local fromWeight = not sameInventory and
+				    (fromInventory.weight + toData.weight - fromData.weight) or 0
 				hookPayload.action = 'swap'
 
 				if not sameInventory then
@@ -1749,39 +1838,55 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 						if containerItem then
 							local toContainer = toInventory.type == 'container'
-							local whitelist = Items.containers[containerItem.name]?.whitelist
-							local blacklist = Items.containers[containerItem.name]?.blacklist
+							local whitelist = Items.containers[containerItem.name]
+							    ?.whitelist
+							local blacklist = Items.containers[containerItem.name]
+							    ?.blacklist
 							local checkItem = toContainer and fromData.name or toData.name
 
 							if (whitelist and not whitelist[checkItem]) or (blacklist and blacklist[checkItem]) then
 								return
 							end
 
-							Inventory.ContainerWeight(containerItem, toContainer and toWeight or fromWeight, playerInventory)
+							Inventory.ContainerWeight(containerItem,
+								toContainer and toWeight or fromWeight, playerInventory)
 						end
 
 						if fromOtherPlayer then
-							TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id, { fromData, 'ui_removed', fromData.count })
-							TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id, { toData, 'ui_added', toData.count })
+							TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id,
+								{ fromData, 'ui_removed', fromData.count })
+							TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id,
+								{ toData, 'ui_added', toData.count })
 						elseif toOtherPlayer then
-							TriggerClientEvent('ox_inventory:itemNotify', toInventory.id, { fromData, 'ui_added', fromData.count })
-							TriggerClientEvent('ox_inventory:itemNotify', toInventory.id, { toData, 'ui_removed', toData.count })
+							TriggerClientEvent('ox_inventory:itemNotify', toInventory.id,
+								{ fromData, 'ui_added', fromData.count })
+							TriggerClientEvent('ox_inventory:itemNotify', toInventory.id,
+								{ toData, 'ui_removed', toData.count })
 						end
 
 						fromInventory.weight = fromWeight
 						toInventory.weight = toWeight
-						toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot) --[[@as table]]
+						toData, fromData = Inventory.SwapSlots(fromInventory, toInventory,
+							data.fromSlot, data.toSlot) --[[@as table]]
 
 						if server.loglevel > 0 then
-							lib.logger(playerInventory.owner, 'swapSlots', ('%sx %s transferred from "%s" to "%s" for %sx %s'):format(fromData.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id, toData.count, toData.name))
+							lib.logger(playerInventory.owner, 'swapSlots',
+								('%sx %s transferred from "%s" to "%s" for %sx %s')
+								:format(fromData.count, fromData.name,
+									fromInventory.owner and fromInventory.label or
+									fromInventory.id,
+									toInventory.owner and toInventory.label or
+									toInventory.id, toData.count, toData.name))
 						end
-					else return false, 'cannot_carry' end
+					else
+						return false, 'cannot_carry'
+					end
 				else
 					if not TriggerEventHooks('swapItems', hookPayload) then return end
 
-					toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
+					toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot,
+						data.toSlot)
 				end
-
 			elseif toData and toData.name == fromData.name and table.matches(toData.metadata, fromData.metadata) then
 				-- Stack items
 				toData.count += data.count
@@ -1802,21 +1907,32 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 					toData.weight = toSlotWeight
 
 					if not sameInventory then
-						fromInventory.weight = fromInventory.weight - fromData.weight + fromSlotWeight
+						fromInventory.weight = fromInventory.weight - fromData.weight +
+						    fromSlotWeight
 						toInventory.weight = totalWeight
 
 						if container then
-							Inventory.ContainerWeight(containerItem, toInventory.type == 'container' and toInventory.weight or fromInventory.weight, playerInventory)
+							Inventory.ContainerWeight(containerItem,
+								toInventory.type == 'container' and toInventory.weight or
+								fromInventory.weight, playerInventory)
 						end
 
 						if fromOtherPlayer then
-							TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id, { fromData, 'ui_removed', data.count })
+							TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id,
+								{ fromData, 'ui_removed', data.count })
 						elseif toOtherPlayer then
-							TriggerClientEvent('ox_inventory:itemNotify', toInventory.id, { toData, 'ui_added', data.count })
+							TriggerClientEvent('ox_inventory:itemNotify', toInventory.id,
+								{ toData, 'ui_added', data.count })
 						end
 
 						if server.loglevel > 0 then
-							lib.logger(playerInventory.owner, 'swapSlots', ('%sx %s transferred from "%s" to "%s"'):format(data.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id))
+							lib.logger(playerInventory.owner, 'swapSlots',
+								('%sx %s transferred from "%s" to "%s"'):format(
+									data.count, fromData.name,
+									fromInventory.owner and fromInventory.label or
+									fromInventory.id,
+									toInventory.owner and toInventory.label or
+									toInventory.id))
 						end
 					end
 
@@ -1843,8 +1959,10 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 						if container then
 							if toContainer and containerItem then
-								local whitelist = Items.containers[containerItem.name]?.whitelist
-								local blacklist = Items.containers[containerItem.name]?.blacklist
+								local whitelist = Items.containers[containerItem.name]
+								    ?.whitelist
+								local blacklist = Items.containers[containerItem.name]
+								    ?.blacklist
 
 								if (whitelist and not whitelist[fromData.name]) or (blacklist and blacklist[fromData.name]) then
 									return
@@ -1856,17 +1974,27 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 						toInventory.weight += toData.weight
 
 						if container then
-							Inventory.ContainerWeight(containerItem, toContainer and toInventory.weight or fromInventory.weight, playerInventory)
+							Inventory.ContainerWeight(containerItem,
+								toContainer and toInventory.weight or
+								fromInventory.weight, playerInventory)
 						end
 
 						if fromOtherPlayer then
-							TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id, { fromData, 'ui_removed', data.count })
+							TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id,
+								{ fromData, 'ui_removed', data.count })
 						elseif toOtherPlayer then
-							TriggerClientEvent('ox_inventory:itemNotify', toInventory.id, { fromData, 'ui_added', data.count })
+							TriggerClientEvent('ox_inventory:itemNotify', toInventory.id,
+								{ fromData, 'ui_added', data.count })
 						end
 
 						if server.loglevel > 0 then
-							lib.logger(playerInventory.owner, 'swapSlots', ('%sx %s transferred from "%s" to "%s"'):format(data.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id))
+							lib.logger(playerInventory.owner, 'swapSlots',
+								('%sx %s transferred from "%s" to "%s"'):format(
+									data.count, fromData.name,
+									fromInventory.owner and fromInventory.label or
+									fromInventory.id,
+									toInventory.owner and toInventory.label or
+									toInventory.id))
 						end
 					end
 
@@ -1876,7 +2004,9 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 					if fromData.count > 0 then
 						toData.metadata = table.clone(toData.metadata)
 					end
-				else return false, 'cannot_carry_other' end
+				else
+					return false, 'cannot_carry_other'
+				end
 			end
 
 			if fromData and fromData.count < 1 then fromData = nil end
@@ -1908,34 +2038,36 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 			if fromInventory.changed ~= nil then fromInventory.changed = true end
 			if toInventory.changed ~= nil then toInventory.changed = true end
 
-            CreateThread(function()
-                if sameInventory then
-                    fromInventory:syncSlotsWithClients({
-                        {
-                            item = fromInventory.items[data.toSlot] or { slot = data.toSlot },
-                            inventory = fromInventory.id
-                        },
-                        {
-                            item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
-                            inventory = fromInventory.id
-                        }
-                    }, true)
-                else
-                    toInventory:syncSlotsWithClients({
-                        {
-                            item = toInventory.items[data.toSlot] or { slot = data.toSlot },
-                            inventory = toInventory.id
-                        }
-                    }, true)
+			CreateThread(function()
+				if sameInventory then
+					fromInventory:syncSlotsWithClients({
+						{
+							item = fromInventory.items[data.toSlot] or { slot = data.toSlot },
+							inventory = fromInventory.id
+						},
+						{
+							item = fromInventory.items[data.fromSlot] or
+							    { slot = data.fromSlot },
+							inventory = fromInventory.id
+						}
+					}, true)
+				else
+					toInventory:syncSlotsWithClients({
+						{
+							item = toInventory.items[data.toSlot] or { slot = data.toSlot },
+							inventory = toInventory.id
+						}
+					}, true)
 
-                    fromInventory:syncSlotsWithClients({
-                        {
-                            item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
-                            inventory = fromInventory.id
-                        }
-                    }, true)
-                end
-            end)
+					fromInventory:syncSlotsWithClients({
+						{
+							item = fromInventory.items[data.fromSlot] or
+							    { slot = data.fromSlot },
+							inventory = fromInventory.id
+						}
+					}, true)
+				end
+			end)
 
 			local resp
 
@@ -1994,6 +2126,7 @@ function Inventory.Confiscate(source)
 		if server.syncInventory then server.syncInventory(inv) end
 	end
 end
+
 exports('ConfiscateInventory', Inventory.Confiscate)
 
 function Inventory.Return(source)
@@ -2003,35 +2136,47 @@ function Inventory.Return(source)
 
 	local items = MySQL.scalar.await('SELECT data FROM ox_inventory WHERE name = ?', { inv.owner })
 
-    if not items then return end
+	if not items then return end
 
 	MySQL.update.await('DELETE FROM ox_inventory WHERE name = ?', { inv.owner })
 
-    items = json.decode(items)
-    local inventory, totalWeight = {}, 0
+	items = json.decode(items)
+	local inventory, totalWeight = {}, 0
 
-    if table.type(items) == 'array' then
-        for i = 1, #items do
-            local data = items[i]
-            if type(data) == 'number' then break end
+	if table.type(items) == 'array' then
+		for i = 1, #items do
+			local data = items[i]
+			if type(data) == 'number' then break end
 
-            local item = Items(data.name)
+			local item = Items(data.name)
 
-            if item then
-                local weight = Inventory.SlotWeight(item, data)
-                totalWeight = totalWeight + weight
-                inventory[data.slot] = {name = data.name, label = item.label, weight = weight, slot = data.slot, count = data.count, description = item.description, metadata = data.metadata, stack = item.stack, close = item.close}
-            end
-        end
-    end
+			if item then
+				local weight = Inventory.SlotWeight(item, data)
+				totalWeight = totalWeight + weight
+				inventory[data.slot] = {
+					name = data.name,
+					label = item.label,
+					weight = weight,
+					slot =
+					    data.slot,
+					count = data.count,
+					description = item.description,
+					metadata = data.metadata,
+					stack =
+					    item.stack,
+					close = item.close
+				}
+			end
+		end
+	end
 
-    inv.changed = true
-    inv.weight = totalWeight
-    inv.items = inventory
+	inv.changed = true
+	inv.weight = totalWeight
+	inv.items = inventory
 
-    TriggerClientEvent('ox_inventory:inventoryReturned', source, { inventory, totalWeight })
+	TriggerClientEvent('ox_inventory:inventoryReturned', source, { inventory, totalWeight })
 
-    if server.syncInventory then server.syncInventory(inv) end
+	if server.syncInventory then server.syncInventory(inv) end
 end
 
 exports('ReturnInventory', Inventory.Return)
@@ -2181,9 +2326,9 @@ function Inventory.GetSlotWithItem(inv, itemName, metadata, strict)
 
 	for _, slotData in pairs(inventory.items) do
 		if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
-            if not Items.UpdateDurability(inventory, slotData, item, nil, os.time()) then
-                return slotData
-            end
+			if not Items.UpdateDurability(inventory, slotData, item, nil, os.time()) then
+				return slotData
+			end
 		end
 	end
 end
@@ -2219,10 +2364,10 @@ function Inventory.GetSlotsWithItem(inv, itemName, metadata, strict)
 
 	for _, slotData in pairs(inventory.items) do
 		if slotData and slotData.name == item.name and (not metadata or tablematch(slotData.metadata, metadata)) then
-            if not Items.UpdateDurability(inventory, slotData, item, nil, os.time()) then
-                n += 1
-                response[n] = slotData
-            end
+			if not Items.UpdateDurability(inventory, slotData, item, nil, os.time()) then
+				n += 1
+				response[n] = slotData
+			end
 		end
 	end
 
@@ -2285,42 +2430,42 @@ exports('GetItemCount', Inventory.GetItemCount)
 ---@return integer?
 ---@return InventorySaveData?
 local function prepareInventorySave(inv, buffer, time)
-    local shouldSave = not inv.datastore and inv.changed
-    local n = 0
+	local shouldSave = not inv.datastore and inv.changed
+	local n = 0
 
-    for k, v in pairs(inv.items) do
-        if not Items.UpdateDurability(inv, v, Items(v.name), nil, time) and shouldSave then
-            n += 1
-            buffer[n] = {
-                name = v.name,
-                count = v.count,
-                slot = k,
-                metadata = next(v.metadata) and v.metadata or nil
-            }
-        end
+	for k, v in pairs(inv.items) do
+		if not Items.UpdateDurability(inv, v, Items(v.name), nil, time) and shouldSave then
+			n += 1
+			buffer[n] = {
+				name = v.name,
+				count = v.count,
+				slot = k,
+				metadata = next(v.metadata) and v.metadata or nil
+			}
+		end
 	end
 
-    if not shouldSave then return end
+	if not shouldSave then return end
 
-    local data = next(buffer) and json.encode(buffer) or nil
-    inv.changed = false
-    table.wipe(buffer)
+	local data = next(buffer) and json.encode(buffer) or nil
+	inv.changed = false
+	table.wipe(buffer)
 
-    if inv.player then
-        if shared.framework == 'esx' then return end
+	if inv.player then
+		if shared.framework == 'esx' then return end
 
-        return 1, { data, inv.owner }
-    end
+		return 1, { data, inv.owner }
+	end
 
-    if inv.type == 'trunk' then
-        return 2, { data, inv.dbId }
-    end
+	if inv.type == 'trunk' then
+		return 2, { data, inv.dbId }
+	end
 
-    if inv.type == 'glovebox' then
-        return 3, { data, inv.dbId }
-    end
+	if inv.type == 'glovebox' then
+		return 3, { data, inv.dbId }
+	end
 
-    return 4, { data, inv.owner and tostring(inv.owner) or '', inv.dbId }
+	return 4, { data, inv.owner and tostring(inv.owner) or '', inv.dbId }
 end
 
 local isSaving = false
@@ -2332,59 +2477,60 @@ local function saveInventories(clearInventories)
 	local time = os.time()
 	local parameters = { {}, {}, {}, {} }
 	local total = { 0, 0, 0, 0, 0 }
-    local buffer = {}
+	local buffer = {}
 
 	for _, inv in pairs(Inventories) do
-        local index, data = prepareInventorySave(inv, buffer, time)
+		local index, data = prepareInventorySave(inv, buffer, time)
 
-        if index and data then
-            total[5] += 1
+		if index and data then
+			total[5] += 1
 
-            if index == 4 and server.bulkstashsave then
-                for i = 1, 3 do
+			if index == 4 and server.bulkstashsave then
+				for i = 1, 3 do
 					total[index] += 1
-                    parameters[index][total[index]] = data[i]
-                end
-            else
+					parameters[index][total[index]] = data[i]
+				end
+			else
 				total[index] += 1
-                parameters[index][total[index]] = data
-            end
-        end
+				parameters[index][total[index]] = data
+			end
+		end
 	end
 
-    if total[5] > 0 then
-        isSaving = true
-        local ok, err = pcall(db.saveInventories, parameters[1], parameters[2], parameters[3], parameters[4], total)
-        isSaving = false
+	if total[5] > 0 then
+		isSaving = true
+		local ok, err = pcall(db.saveInventories, parameters[1], parameters[2], parameters[3], parameters[4],
+			total)
+		isSaving = false
 
-        if not ok and err then return lib.print.error(err) end
-    end
+		if not ok and err then return lib.print.error(err) end
+	end
 
-    if not clearInventories then return end
+	if not clearInventories then return end
 
-    for _, inv in pairs(Inventories) do
-        if not inv.open and not inv.player then
-            -- clear inventory from memory if unused for x minutes, or on entity/netid mismatch
-            if inv.type == 'glovebox' or inv.type == 'trunk' then
-                if NetworkGetEntityFromNetworkId(inv.netid) ~= inv.entityId then
-                    Inventory.Remove(inv)
-                end
-            elseif time - inv.time >= inventoryClearTime then
-                Inventory.Remove(inv)
-            end
-        end
-    end
+	for _, inv in pairs(Inventories) do
+		if not inv.open and not inv.player then
+			-- clear inventory from memory if unused for x minutes, or on entity/netid mismatch
+			if inv.type == 'glovebox' or inv.type == 'trunk' then
+				if NetworkGetEntityFromNetworkId(inv.netid) ~= inv.entityId then
+					Inventory.Remove(inv)
+				end
+			elseif time - inv.time >= inventoryClearTime then
+				Inventory.Remove(inv)
+			end
+		end
+	end
 end
 
 lib.cron.new('*/5 * * * *', function()
-    saveInventories(true)
+	saveInventories(true)
 end)
 
 function Inventory.SaveInventories(lock, clearInventories)
 	Inventory.Lock = lock or nil
 
 	Inventory.CloseAll()
-    saveInventories(clearInventories)
+	saveInventories(clearInventories)
 end
 
 AddEventHandler('playerDropped', function()
@@ -2400,7 +2546,7 @@ AddEventHandler('txAdmin:events:serverShuttingDown', function()
 end)
 
 AddEventHandler('txAdmin:events:scheduledRestart', function(eventData)
-    if eventData.secondsRemaining ~= 60 then return end
+	if eventData.secondsRemaining ~= 60 then return end
 
 	Inventory.SaveInventories(true, true)
 end)
@@ -2438,11 +2584,11 @@ local function giveItem(playerId, slot, target, count)
 
 		if not data then return end
 
-        local targetState = Player(target).state
+		local targetState = Player(target).state
 
-        if targetState.invBusy then
-            return { 'cannot_give', count, data.label }
-        end
+		if targetState.invBusy then
+			return { 'cannot_give', count, data.label }
+		end
 
 		local item = Items(data.name)
 
@@ -2467,20 +2613,22 @@ local function giveItem(playerId, slot, target, count)
 		end)
 
 		if TriggerEventHooks('swapItems', {
-			source = fromInventory.id,
-			fromInventory = fromInventory.id,
-			fromType = fromInventory.type,
-			toInventory = toInventory.id,
-			toType = toInventory.type,
-			count = count,
-			action = 'give',
-			fromSlot = data,
-		}) then
+			    source = fromInventory.id,
+			    fromInventory = fromInventory.id,
+			    fromType = fromInventory.type,
+			    toInventory = toInventory.id,
+			    toType = toInventory.type,
+			    count = count,
+			    action = 'give',
+			    fromSlot = data,
+		    }) then
 			---@todo manually call swapItems or something?
 			if Inventory.AddItem(toInventory, item, count, data.metadata, toSlot) then
 				if Inventory.RemoveItem(fromInventory, item, count, data.metadata, slot) then
 					if server.loglevel > 0 then
-						lib.logger(fromInventory.owner, 'giveItem', ('"%s" gave %sx %s to "%s"'):format(fromInventory.label, count, data.name, toInventory.label))
+						lib.logger(fromInventory.owner, 'giveItem',
+							('"%s" gave %sx %s to "%s"'):format(fromInventory.label, count,
+								data.name, toInventory.label))
 					end
 
 					return
@@ -2523,7 +2671,7 @@ local function updateWeapon(source, action, value, slot, specialAmmo)
 							{ item = item }
 						}, inventory.weight)
 
-			            if server.syncInventory then server.syncInventory(inventory) end
+						if server.syncInventory then server.syncInventory(inventory) end
 
 						return true
 					end
@@ -2572,22 +2720,24 @@ local function updateWeapon(source, action, value, slot, specialAmmo)
 					weapon.metadata.durability = math.floor(value)
 					weapon.metadata.ammo = weapon.metadata.durability
 				elseif value < weapon.metadata.ammo then
-					local durability = Items(weapon.name).durability * math.abs((weapon.metadata.ammo or 0.1) - value)
+					local durability = Items(weapon.name).durability *
+					    math.abs((weapon.metadata.ammo or 0.1) - value)
 					weapon.metadata.ammo = value
 					weapon.metadata.durability = weapon.metadata.durability - durability
 					weapon.weight = Inventory.SlotWeight(item, weapon)
 				end
 			elseif action == 'melee' and value > 0 then
-				weapon.metadata.durability = weapon.metadata.durability - ((Items(weapon.name).durability or 1) * value)
+				weapon.metadata.durability = weapon.metadata.durability -
+				    ((Items(weapon.name).durability or 1) * value)
 			end
 
-            if (weapon.metadata.durability or 0) < 0 then
-                weapon.metadata.durability = 0
-            end
+			if (weapon.metadata.durability or 0) < 0 then
+				weapon.metadata.durability = 0
+			end
 
-            if item.hash == `WEAPON_PETROLCAN` then
-                weapon.weight = Inventory.SlotWeight(item, weapon)
-            end
+			if item.hash == `WEAPON_PETROLCAN` then
+				weapon.weight = Inventory.SlotWeight(item, weapon)
+			end
 
 			if action ~= 'throw' then
 				inventory:syncSlotsWithPlayer({
@@ -2667,7 +2817,8 @@ local function checkStashProperties(properties)
 						coords[i] = vec3(coords[i].x, coords[i].y, coords[i].z)
 					end
 				else
-					error(('received %s for stash coords (expected vector3 or array of vector3)'):format(typeof))
+					error(('received %s for stash coords (expected vector3 or array of vector3)')
+						:format(typeof))
 				end
 			end
 		end
@@ -2737,7 +2888,8 @@ function Inventory.CreateTemporaryStash(properties)
 	properties.name = generateInvId('temp')
 
 	local name, slots, maxWeight, coords = checkStashProperties(properties)
-	local inventory = Inventory.Create(name, properties.label, 'temp', slots, 0, maxWeight, properties.owner, {}, properties.groups)
+	local inventory = Inventory.Create(name, properties.label, 'temp', slots, 0, maxWeight, properties.owner, {},
+		properties.groups)
 
 	if not inventory then return end
 

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -129,8 +129,7 @@ local function loadInventoryData(data, player, ignoreSecurityChecks)
 				entity = NetworkGetEntityFromNetworkId(data.netid)
 
 				if not entity then
-					return shared.info(
-						'Failed to load vehicle inventory data (no entity exists with given netid).')
+					return shared.info('Failed to load vehicle inventory data (no entity exists with given netid).')
 				end
 
 				data.entityId = entity
@@ -150,8 +149,7 @@ local function loadInventoryData(data, player, ignoreSecurityChecks)
 				end
 
 				if not entity then
-					return shared.info(
-						'Failed to load vehicle inventory data (no entity exists with given plate).')
+					return shared.info('Failed to load vehicle inventory data (no entity exists with given plate).')
 				end
 			end
 
@@ -173,8 +171,7 @@ local function loadInventoryData(data, player, ignoreSecurityChecks)
 				dbId = data.id:sub(6)
 			end
 
-			inventory = Inventory.Create(data.id, plate, data.type, storage[1], 0, storage[2], false, nil,
-				nil, dbId)
+			inventory = Inventory.Create(data.id, plate, data.type, storage[1], 0, storage[2], false, nil, nil, dbId)
 		end
 	elseif data.type == 'policeevidence' then
 		inventory = Inventory.Create(data.id, locale('police_evidence'), data.type, 100, 0, 100000, false)
@@ -198,8 +195,8 @@ local function loadInventoryData(data, player, ignoreSecurityChecks)
 			inventory = Inventories[owner and ('%s:%s'):format(stash.name, owner) or stash.name]
 
 			if not inventory then
-				inventory = Inventory.Create(stash.name, stash.label or stash.name, 'stash', stash.slots,
-					0, stash.maxWeight, owner, nil, stash.groups)
+				inventory = Inventory.Create(stash.name, stash.label or stash.name, 'stash', stash.slots, 0,
+					stash.maxWeight, owner, nil, stash.groups)
 				inventory.coords = stash.coords
 				inventory.distance = stash.distance
 			end
@@ -223,8 +220,7 @@ setmetatable(Inventory, {
 		elseif type(inv) == 'table' then
 			if inv.__index then return inv end
 
-			return not inv.owner and Inventories[inv.id] or
-			    loadInventoryData(inv, player, ignoreSecurityChecks)
+			return not inv.owner and Inventories[inv.id] or loadInventoryData(inv, player, ignoreSecurityChecks)
 		end
 
 		return Inventories[inv] or loadInventoryData({ id = inv }, player, ignoreSecurityChecks)
@@ -269,8 +265,8 @@ function Inventory.GetContainerFromSlot(inv, slotId)
 	local container = Inventory(slotData.metadata.container)
 
 	if not container then
-		container = Inventory.Create(slotData.metadata.container, slotData.label, 'container',
-			slotData.metadata.size[1], 0, slotData.metadata.size[2], false)
+		container = Inventory.Create(slotData.metadata.container, slotData.label, 'container', slotData.metadata.size[1],
+			0, slotData.metadata.size[2], false)
 	end
 
 	return container
@@ -397,8 +393,7 @@ function Inventory.SetSlot(inv, item, count, metadata, slot)
 			weight = item.weight,
 			slot = slot,
 			count = newCount,
-			description =
-			    item.description,
+			description = item.description,
 			metadata = metadata,
 			stack = item.stack,
 			close = item.close
@@ -517,7 +512,7 @@ local function hasActiveInventory(playerId, owner)
 					playerName = GetPlayerName(activePlayer),
 					fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
 					license = GetPlayerIdentifierByType(activePlayer, 'license2') or
-					    GetPlayerIdentifierByType(activePlayer, 'license'),
+						GetPlayerIdentifierByType(activePlayer, 'license'),
 				}, {
 					indent = true,
 					sort_keys = true
@@ -560,7 +555,7 @@ RegisterCommand('clearActiveIdentifier', function(source, args)
 			playerName = GetPlayerName(activePlayer),
 			fivem = GetPlayerIdentifierByType(activePlayer, 'fivem'),
 			license = GetPlayerIdentifierByType(activePlayer, 'license2') or
-			    GetPlayerIdentifierByType(activePlayer, 'license'),
+				GetPlayerIdentifierByType(activePlayer, 'license'),
 		}, {
 			indent = true,
 			sort_keys = true
@@ -821,7 +816,7 @@ local function generateItems(inv, invType, items)
 				slot = i,
 				count = count,
 				description =
-				    item.description,
+					item.description,
 				metadata = metadata,
 				stack = item.stack,
 				close = item.close
@@ -877,13 +872,12 @@ function Inventory.Load(id, invType, owner)
 					name = item.name,
 					label = item.label,
 					weight = slotWeight,
-					slot =
-					    v.slot,
-					count = v.count,
+					slot = v.slot,
+					count =
+						v.count,
 					description = item.description,
 					metadata = v.metadata,
-					stack =
-					    item.stack,
+					stack = item.stack,
 					close = item.close
 				}
 			end
@@ -1091,14 +1085,12 @@ function Inventory.SetMetadata(inv, slotId, metadata)
 		if Utils.IsValidImageUrl(metadata.imageurl) then
 			Utils.DiscordEmbed('Valid image URL',
 				('Updated item "%s" (%s) with valid url in "%s".\n%s\nid: %s\nowner: %s'):format(
-					metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id,
-					inv.owner,
+					metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id, inv.owner,
 					metadata.imageurl), metadata.imageurl, 65280)
 		else
 			Utils.DiscordEmbed('Invalid image URL',
 				('Updated item "%s" (%s) with invalid url in "%s".\n%s\nid: %s\nowner: %s'):format(
-					metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id,
-					inv.owner,
+					metadata.label or slot.label, slot.name, inv.label, metadata.imageurl, inv.id, inv.owner,
 					metadata.imageurl), metadata.imageurl, 16711680)
 			metadata.imageurl = nil
 		end
@@ -1124,8 +1116,7 @@ function Inventory.SetSlotCount(inv, slots)
 
 	for playerId in pairs(inv.openedBy) do
 		if playerId ~= inv.id then
-			TriggerClientEvent('ox_inventory:refreshSlotCount', playerId,
-				{ inventoryId = inv.id, slots = inv.slots })
+			TriggerClientEvent('ox_inventory:refreshSlotCount', playerId, { inventoryId = inv.id, slots = inv.slots })
 		end
 	end
 end
@@ -1143,8 +1134,7 @@ function Inventory.SetMaxWeight(inv, maxWeight)
 	inv.maxWeight = maxWeight
 
 	if inv.player then
-		TriggerClientEvent('ox_inventory:refreshMaxWeight', inv.id,
-			{ inventoryId = inv.id, maxWeight = inv.maxWeight })
+		TriggerClientEvent('ox_inventory:refreshMaxWeight', inv.id, { inventoryId = inv.id, maxWeight = inv.maxWeight })
 	end
 
 	for playerId in pairs(inv.openedBy) do
@@ -1186,8 +1176,17 @@ function Inventory.AddItem(inv, item, count, metadata, slot, cb)
 		local slotData = inv.items[slot]
 		slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
 
-		if not slotData or (item.stack and slotData.name == item.name and table.matches(slotData.metadata, slotMetadata)) then
+		if not slotData or item.stack == true then
 			toSlot = slot
+		elseif slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
+			if type(item.stack) == "number" then
+				local freeSpace = item.stack - slotData.count
+				if freeSpace > 0 then
+					slotCount = math.min(count, freeSpace)
+					toSlot = slot
+					count = count - slotCount
+				end
+			end
 		end
 	end
 
@@ -1198,23 +1197,41 @@ function Inventory.AddItem(inv, item, count, metadata, slot, cb)
 		for i = 1, inv.slots do
 			local slotData = items[i]
 
-			if item.stack and slotData ~= nil and slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
+			if type(item.stack) == 'number' and slotData ~= nil and slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
+				local freeSpace = item.stack - slotData.count
+				if freeSpace > 0 then
+					if count <= freeSpace then
+						toSlot = i
+						slotCount = count
+						count = 0
+						break
+					else
+						if not toSlot or type(toSlot) ~= 'table' then toSlot = {} end
+						toSlot[#toSlot + 1] = { slot = i, count = freeSpace, metadata = slotMetadata }
+						count -= freeSpace
+					end
+				end
+			elseif item.stack == true and slotData ~= nil and slotData.name == item.name and table.matches(slotData.metadata, slotMetadata) then
 				toSlot = i
 				break
 			elseif not item.stack and not slotData then
 				if not toSlot then toSlot = {} end
-
 				toSlot[#toSlot + 1] = { slot = i, count = slotCount, metadata = slotMetadata }
-
 				if count == slotCount then
 					break
 				end
-
 				count -= 1
-				slotMetadata, slotCount = Items.Metadata(inv.id, item,
-					metadata and table.clone(metadata) or {}, count)
-			elseif not toSlot and not slotData then
-				toSlot = i
+				slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata and table.clone(metadata) or {}, count)
+			elseif not slotData then
+				if type(item.stack) == 'number' and count > 0 then
+					if not toSlot or type(toSlot) ~= 'table' then toSlot = {} end
+					local addCount = math.min(count, item.stack)
+					toSlot[#toSlot + 1] = { slot = i, count = addCount, metadata = slotMetadata }
+					count -= addCount
+					if count <= 0 then break end
+				elseif not toSlot then
+					toSlot = i
+				end
 			end
 		end
 	end
@@ -1414,8 +1431,7 @@ function Inventory.RemoveItem(inv, item, count, metadata, slot, ignoreTotal, str
 		for k, v in pairs(itemSlots) do
 			if removed < total then
 				if v == count then
-					TriggerClientEvent('ox_inventory:itemNotify', inv.id,
-						{ inv.items[k], 'ui_removed', v })
+					TriggerClientEvent('ox_inventory:itemNotify', inv.id, { inv.items[k], 'ui_removed', v })
 
 					removed = total
 					inv.weight -= inv.items[k].weight
@@ -1427,8 +1443,7 @@ function Inventory.RemoveItem(inv, item, count, metadata, slot, ignoreTotal, str
 					removed = total
 					count = v - count
 				else
-					TriggerClientEvent('ox_inventory:itemNotify', inv.id,
-						{ inv.items[k], 'ui_removed', v })
+					TriggerClientEvent('ox_inventory:itemNotify', inv.id, { inv.items[k], 'ui_removed', v })
 
 					removed = removed + v
 					count = count - v
@@ -1611,9 +1626,8 @@ exports('CreateDropFromPlayer', function(playerId)
 	if not playerInventory or not next(playerInventory.items) then return end
 
 	local dropId = generateInvId()
-	local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop',
-		playerInventory.slots, playerInventory.weight, playerInventory.maxWeight, false,
-		table.clone(playerInventory.items))
+	local inventory = Inventory.Create(dropId, ('Drop %s'):format(dropId:gsub('%D', '')), 'drop', playerInventory.slots,
+		playerInventory.weight, playerInventory.maxWeight, false, table.clone(playerInventory.items))
 
 	if not inventory then return end
 
@@ -1658,17 +1672,17 @@ local function dropItem(source, playerInventory, fromData, data)
 	local dropId = generateInvId('drop')
 
 	if not TriggerEventHooks('swapItems', {
-		    source = source,
-		    fromInventory = playerInventory.id,
-		    fromSlot = fromData,
-		    fromType = playerInventory.type,
-		    toInventory = 'newdrop',
-		    toSlot = data.toSlot,
-		    toType = 'drop',
-		    count = data.count,
-		    action = 'move',
-		    dropId = dropId,
-	    }) then
+			source = source,
+			fromInventory = playerInventory.id,
+			fromSlot = fromData,
+			fromType = playerInventory.type,
+			toInventory = 'newdrop',
+			toSlot = data.toSlot,
+			toType = 'drop',
+			count = data.count,
+			action = 'move',
+			dropId = dropId,
+		}) then
 		return
 	end
 
@@ -1698,13 +1712,12 @@ local function dropItem(source, playerInventory, fromData, data)
 	Inventory.Drops[dropId] = { coords = inventory.coords, instance = data.instance }
 	playerInventory.changed = true
 
-	TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId],
-		playerInventory.open and source, slot)
+	TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId], playerInventory.open and source,
+		slot)
 
 	if server.loglevel > 0 then
 		lib.logger(playerInventory.owner, 'swapSlots',
-			('%sx %s transferred from "%s" to "%s"'):format(data.count, toData.name, playerInventory.label,
-				dropId))
+			('%sx %s transferred from "%s" to "%s"'):format(data.count, toData.name, playerInventory.label, dropId))
 	end
 
 	if server.syncInventory then server.syncInventory(playerInventory) end
@@ -1728,7 +1741,6 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 	if data.count < 1 then return end
 
 	local playerInventory = Inventory(source)
-
 	if not playerInventory then return end
 
 	local toInventory = (data.toType == 'player' and playerInventory) or Inventory(playerInventory.open)
@@ -1746,14 +1758,8 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 	if activeSlots[fromRef] or activeSlots[toRef] then
 		return false, {
-			{
-				item = toInventory.items[data.toSlot] or { slot = data.toSlot },
-				inventory = toInventory.id
-			},
-			{
-				item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
-				inventory = fromInventory.id
-			}
+			{ item = toInventory.items[data.toSlot] or { slot = data.toSlot },       inventory = toInventory.id },
+			{ item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
 		}
 	end
 
@@ -1764,7 +1770,6 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 	if not sameInventory and (fromInventory.type == 'policeevidence' or (toInventory.type == 'policeevidence' and toData)) then
 		local group, rank = server.hasGroup(playerInventory, shared.police)
-
 		if not group or server.evidencegrade > rank then
 			return false, 'evidence_cannot_take'
 		end
@@ -1783,14 +1788,8 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 		if not fromData then
 			return false, {
-				{
-					item = { slot = data.fromSlot },
-					inventory = fromInventory.id
-				},
-				{
-					item = toData or { slot = data.toSlot },
-					inventory = toInventory.id
-				}
+				{ item = { slot = data.fromSlot },         inventory = fromInventory.id },
+				{ item = toData or { slot = data.toSlot }, inventory = toInventory.id }
 			}
 		end
 
@@ -1807,7 +1806,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 			if toData and toData.metadata.container and fromInventory.type == 'container' then return false end
 
 			local container, containerItem = (not sameInventory and playerInventory.containerSlot) and
-			    (fromInventory.type == 'container' and fromInventory or toInventory)
+				(fromInventory.type == 'container' and fromInventory or toInventory)
 
 			if container then
 				containerItem = playerInventory.items[playerInventory.containerSlot]
@@ -1825,182 +1824,73 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 			}
 
 			if toData and ((toData.name ~= fromData.name) or not toData.stack or (not table.matches(toData.metadata, fromData.metadata))) then
-				-- Swap items
-				local toWeight = not sameInventory and
-				    (toInventory.weight - toData.weight + fromData.weight) or 0
-				local fromWeight = not sameInventory and
-				    (fromInventory.weight + toData.weight - fromData.weight) or 0
+				local toWeight = not sameInventory and (toInventory.weight - toData.weight + fromData.weight) or 0
+				local fromWeight = not sameInventory and (fromInventory.weight + toData.weight - fromData.weight) or 0
 				hookPayload.action = 'swap'
 
 				if not sameInventory then
 					if (toWeight <= toInventory.maxWeight and fromWeight <= fromInventory.maxWeight) then
 						if not TriggerEventHooks('swapItems', hookPayload) then return end
-
 						if containerItem then
 							local toContainer = toInventory.type == 'container'
-							local whitelist = Items.containers[containerItem.name]
-							    ?.whitelist
-							local blacklist = Items.containers[containerItem.name]
-							    ?.blacklist
+							local whitelist = Items.containers[containerItem.name]?.whitelist
+							local blacklist = Items.containers[containerItem.name]?.blacklist
 							local checkItem = toContainer and fromData.name or toData.name
-
-							if (whitelist and not whitelist[checkItem]) or (blacklist and blacklist[checkItem]) then
-								return
-							end
-
-							Inventory.ContainerWeight(containerItem,
-								toContainer and toWeight or fromWeight, playerInventory)
+							if (whitelist and not whitelist[checkItem]) or (blacklist and blacklist[checkItem]) then return end
+							Inventory.ContainerWeight(containerItem, toContainer and toWeight or fromWeight,
+								playerInventory)
 						end
-
-						if fromOtherPlayer then
-							TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id,
-								{ fromData, 'ui_removed', fromData.count })
-							TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id,
-								{ toData, 'ui_added', toData.count })
-						elseif toOtherPlayer then
-							TriggerClientEvent('ox_inventory:itemNotify', toInventory.id,
-								{ fromData, 'ui_added', fromData.count })
-							TriggerClientEvent('ox_inventory:itemNotify', toInventory.id,
-								{ toData, 'ui_removed', toData.count })
-						end
-
 						fromInventory.weight = fromWeight
 						toInventory.weight = toWeight
-						toData, fromData = Inventory.SwapSlots(fromInventory, toInventory,
-							data.fromSlot, data.toSlot) --[[@as table]]
-
-						if server.loglevel > 0 then
-							lib.logger(playerInventory.owner, 'swapSlots',
-								('%sx %s transferred from "%s" to "%s" for %sx %s')
-								:format(fromData.count, fromData.name,
-									fromInventory.owner and fromInventory.label or
-									fromInventory.id,
-									toInventory.owner and toInventory.label or
-									toInventory.id, toData.count, toData.name))
-						end
+						toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
 					else
 						return false, 'cannot_carry'
 					end
 				else
 					if not TriggerEventHooks('swapItems', hookPayload) then return end
-
-					toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot,
-						data.toSlot)
+					toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
 				end
 			elseif toData and toData.name == fromData.name and table.matches(toData.metadata, fromData.metadata) then
-				-- Stack items
-				toData.count += data.count
-				fromData.count -= data.count
-				local toSlotWeight = Inventory.SlotWeight(Items(toData.name), toData)
-				local totalWeight = toInventory.weight - toData.weight + toSlotWeight
+				local maxStack = (type(toData.stack) == 'number' and toData.stack) or false
+				if maxStack then
+					local spaceLeft = maxStack - toData.count
+					if spaceLeft <= 0 then return false, 'stack_full' end
 
-				if fromInventory.type == 'container' or sameInventory or totalWeight <= toInventory.maxWeight then
-					hookPayload.action = 'stack'
-
-					if not TriggerEventHooks('swapItems', hookPayload) then
-						toData.count -= data.count
-						fromData.count += data.count
-						return
+					local moveAmount = math.min(data.count, fromData.count, spaceLeft)
+					toData.count = toData.count + moveAmount
+					fromData.count = fromData.count - moveAmount
+					if fromData.count > 0 then
+						toData.metadata = table.clone(toData.metadata)
+						fromData.metadata = table.clone(fromData.metadata)
 					end
-
-					local fromSlotWeight = Inventory.SlotWeight(Items(fromData.name), fromData)
-					toData.weight = toSlotWeight
-
-					if not sameInventory then
-						fromInventory.weight = fromInventory.weight - fromData.weight +
-						    fromSlotWeight
-						toInventory.weight = totalWeight
-
-						if container then
-							Inventory.ContainerWeight(containerItem,
-								toInventory.type == 'container' and toInventory.weight or
-								fromInventory.weight, playerInventory)
-						end
-
-						if fromOtherPlayer then
-							TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id,
-								{ fromData, 'ui_removed', data.count })
-						elseif toOtherPlayer then
-							TriggerClientEvent('ox_inventory:itemNotify', toInventory.id,
-								{ toData, 'ui_added', data.count })
-						end
-
-						if server.loglevel > 0 then
-							lib.logger(playerInventory.owner, 'swapSlots',
-								('%sx %s transferred from "%s" to "%s"'):format(
-									data.count, fromData.name,
-									fromInventory.owner and fromInventory.label or
-									fromInventory.id,
-									toInventory.owner and toInventory.label or
-									toInventory.id))
-						end
-					end
-
-					fromData.weight = fromSlotWeight
+					toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
+					fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
+					hookPayload.action = 'stackItems'
+					hookPayload.moved = moveAmount
+					hookPayload.leftover = data.count - moveAmount
+					if not TriggerEventHooks('swapItems', hookPayload) then return end
 				else
-					toData.count -= data.count
-					fromData.count += data.count
-					return false, 'cannot_carry'
+					local tempCount, tempWeight = toData.count, toData.weight
+					toData.count = fromData.count
+					toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
+					fromData.count = tempCount
+					fromData.weight = tempWeight
+
+					hookPayload.action = 'swapCounts'
+					if not TriggerEventHooks('swapItems', hookPayload) then return end
 				end
 			elseif data.count <= fromData.count then
-				-- Move item to an empty slot
 				toData = table.clone(fromData)
 				toData.count = data.count
 				toData.slot = data.toSlot
 				toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
-
 				if fromInventory.type == 'container' or sameInventory or (toInventory.weight + toData.weight <= toInventory.maxWeight) then
 					hookPayload.action = 'move'
-
 					if not TriggerEventHooks('swapItems', hookPayload) then return end
-
-					if not sameInventory then
-						local toContainer = toInventory.type == 'container'
-
-						if container then
-							if toContainer and containerItem then
-								local whitelist = Items.containers[containerItem.name]
-								    ?.whitelist
-								local blacklist = Items.containers[containerItem.name]
-								    ?.blacklist
-
-								if (whitelist and not whitelist[fromData.name]) or (blacklist and blacklist[fromData.name]) then
-									return
-								end
-							end
-						end
-
-						fromInventory.weight -= toData.weight
-						toInventory.weight += toData.weight
-
-						if container then
-							Inventory.ContainerWeight(containerItem,
-								toContainer and toInventory.weight or
-								fromInventory.weight, playerInventory)
-						end
-
-						if fromOtherPlayer then
-							TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id,
-								{ fromData, 'ui_removed', data.count })
-						elseif toOtherPlayer then
-							TriggerClientEvent('ox_inventory:itemNotify', toInventory.id,
-								{ fromData, 'ui_added', data.count })
-						end
-
-						if server.loglevel > 0 then
-							lib.logger(playerInventory.owner, 'swapSlots',
-								('%sx %s transferred from "%s" to "%s"'):format(
-									data.count, fromData.name,
-									fromInventory.owner and fromInventory.label or
-									fromInventory.id,
-									toInventory.owner and toInventory.label or
-									toInventory.id))
-						end
-					end
-
+					fromInventory.weight -= toData.weight
+					toInventory.weight += toData.weight
 					fromData.count -= data.count
 					fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
-
 					if fromData.count > 0 then
 						toData.metadata = table.clone(toData.metadata)
 					end
@@ -2011,24 +1901,15 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 			if fromData and fromData.count < 1 then fromData = nil end
 
-			---@type updateSlot[]
 			local items = {}
-
 			if fromInventory.player and not fromOtherPlayer then
 				if toInventory.type == 'container' and containerItem then
-					items[#items + 1] = {
-						item = containerItem,
-						inventory = playerInventory.id
-					}
+					items[#items + 1] = { item = containerItem, inventory = playerInventory.id }
 				end
 			end
-
 			if toInventory.player and not toOtherPlayer then
 				if fromInventory.type == 'container' and containerItem then
-					items[#items + 1] = {
-						item = containerItem,
-						inventory = playerInventory.id
-					}
+					items[#items + 1] = { item = containerItem, inventory = playerInventory.id }
 				end
 			end
 
@@ -2041,52 +1922,30 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 			CreateThread(function()
 				if sameInventory then
 					fromInventory:syncSlotsWithClients({
-						{
-							item = fromInventory.items[data.toSlot] or { slot = data.toSlot },
-							inventory = fromInventory.id
-						},
-						{
-							item = fromInventory.items[data.fromSlot] or
-							    { slot = data.fromSlot },
-							inventory = fromInventory.id
-						}
+						{ item = fromInventory.items[data.toSlot] or { slot = data.toSlot },     inventory = fromInventory.id },
+						{ item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
 					}, true)
 				else
 					toInventory:syncSlotsWithClients({
-						{
-							item = toInventory.items[data.toSlot] or { slot = data.toSlot },
-							inventory = toInventory.id
-						}
+						{ item = toInventory.items[data.toSlot] or { slot = data.toSlot }, inventory = toInventory.id }
 					}, true)
-
 					fromInventory:syncSlotsWithClients({
-						{
-							item = fromInventory.items[data.fromSlot] or
-							    { slot = data.fromSlot },
-							inventory = fromInventory.id
-						}
+						{ item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot }, inventory = fromInventory.id }
 					}, true)
 				end
 			end)
 
 			local resp
-
 			if next(items) then
 				resp = { weight = playerInventory.weight, items = items }
 			end
 
 			if server.syncInventory then
-				if fromInventory.player then
-					server.syncInventory(fromInventory)
-				end
-
-				if toInventory.player and not sameInventory then
-					server.syncInventory(toInventory)
-				end
+				if fromInventory.player then server.syncInventory(fromInventory) end
+				if toInventory.player and not sameInventory then server.syncInventory(toInventory) end
 			end
 
 			local weaponSlot
-
 			if toInventory.weapon == data.toSlot then
 				if not sameInventory then
 					toInventory.weapon = nil
@@ -2096,7 +1955,6 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 					toInventory.weapon = weaponSlot
 				end
 			end
-
 			if fromInventory.weapon == data.fromSlot then
 				if not sameInventory then
 					fromInventory.weapon = nil
@@ -2157,14 +2015,14 @@ function Inventory.Return(source)
 					name = data.name,
 					label = item.label,
 					weight = weight,
-					slot =
-					    data.slot,
-					count = data.count,
+					slot = data.slot,
+					count =
+						data.count,
 					description = item.description,
 					metadata = data.metadata,
-					stack =
-					    item.stack,
-					close = item.close
+					stack = item.stack,
+					close = item
+						.close
 				}
 			end
 		end
@@ -2299,8 +2157,10 @@ function Inventory.GetSlotForItem(inv, itemName, metadata)
 		local slotData = items[i]
 
 		if item.stack and slotData and slotData.name == item.name and table.matches(slotData.metadata, metadata) then
-			return i
-		elseif not item.stack and not slotData and not emptySlot then
+			if slotData.count < (slotData.stack or item.stack) then
+				return i
+			end
+		elseif not slotData and not emptySlot then
 			emptySlot = i
 		end
 	end
@@ -2499,8 +2359,7 @@ local function saveInventories(clearInventories)
 
 	if total[5] > 0 then
 		isSaving = true
-		local ok, err = pcall(db.saveInventories, parameters[1], parameters[2], parameters[3], parameters[4],
-			total)
+		local ok, err = pcall(db.saveInventories, parameters[1], parameters[2], parameters[3], parameters[4], total)
 		isSaving = false
 
 		if not ok and err then return lib.print.error(err) end
@@ -2613,22 +2472,21 @@ local function giveItem(playerId, slot, target, count)
 		end)
 
 		if TriggerEventHooks('swapItems', {
-			    source = fromInventory.id,
-			    fromInventory = fromInventory.id,
-			    fromType = fromInventory.type,
-			    toInventory = toInventory.id,
-			    toType = toInventory.type,
-			    count = count,
-			    action = 'give',
-			    fromSlot = data,
-		    }) then
+				source = fromInventory.id,
+				fromInventory = fromInventory.id,
+				fromType = fromInventory.type,
+				toInventory = toInventory.id,
+				toType = toInventory.type,
+				count = count,
+				action = 'give',
+				fromSlot = data,
+			}) then
 			---@todo manually call swapItems or something?
 			if Inventory.AddItem(toInventory, item, count, data.metadata, toSlot) then
 				if Inventory.RemoveItem(fromInventory, item, count, data.metadata, slot) then
 					if server.loglevel > 0 then
 						lib.logger(fromInventory.owner, 'giveItem',
-							('"%s" gave %sx %s to "%s"'):format(fromInventory.label, count,
-								data.name, toInventory.label))
+							('"%s" gave %sx %s to "%s"'):format(fromInventory.label, count, data.name, toInventory.label))
 					end
 
 					return
@@ -2720,15 +2578,13 @@ local function updateWeapon(source, action, value, slot, specialAmmo)
 					weapon.metadata.durability = math.floor(value)
 					weapon.metadata.ammo = weapon.metadata.durability
 				elseif value < weapon.metadata.ammo then
-					local durability = Items(weapon.name).durability *
-					    math.abs((weapon.metadata.ammo or 0.1) - value)
+					local durability = Items(weapon.name).durability * math.abs((weapon.metadata.ammo or 0.1) - value)
 					weapon.metadata.ammo = value
 					weapon.metadata.durability = weapon.metadata.durability - durability
 					weapon.weight = Inventory.SlotWeight(item, weapon)
 				end
 			elseif action == 'melee' and value > 0 then
-				weapon.metadata.durability = weapon.metadata.durability -
-				    ((Items(weapon.name).durability or 1) * value)
+				weapon.metadata.durability = weapon.metadata.durability - ((Items(weapon.name).durability or 1) * value)
 			end
 
 			if (weapon.metadata.durability or 0) < 0 then
@@ -2817,8 +2673,7 @@ local function checkStashProperties(properties)
 						coords[i] = vec3(coords[i].x, coords[i].y, coords[i].z)
 					end
 				else
-					error(('received %s for stash coords (expected vector3 or array of vector3)')
-						:format(typeof))
+					error(('received %s for stash coords (expected vector3 or array of vector3)'):format(typeof))
 				end
 			end
 		end

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -10,309 +10,290 @@ local locations = shared.target and 'targets' or 'locations'
 ---@field weight number
 
 local function setupShopItems(id, shopType, shopName, groups)
-    local shop = id and Shops[shopType][id] or Shops[shopType] --[[@as OxShop]]
+	local shop = id and Shops[shopType][id] or Shops[shopType] --[[@as OxShop]]
 
-    for i = 1, shop.slots do
-        local slot = shop.items[i]
+	for i = 1, shop.slots do
+		local slot = shop.items[i]
 
-        if slot.grade and not groups then
-            print(('^1attempted to restrict slot %s (%s) to grade %s, but %s has no job restriction^0'):format(id,
-                slot.name, json.encode(slot.grade), shopName))
-            slot.grade = nil
-        end
+		if slot.grade and not groups then
+			print(('^1attempted to restrict slot %s (%s) to grade %s, but %s has no job restriction^0'):format(id,
+				slot.name, json.encode(slot.grade), shopName))
+			slot.grade = nil
+		end
 
-        local Item = Items(slot.name)
+		local Item = Items(slot.name)
 
-        if Item then
-            ---@type OxShopItem
-            slot = {
-                name = Item.name,
-                slot = i,
-                weight = Item.weight,
-                count = slot.count,
-                price = (server.randomprices and (not slot.currency or slot.currency == 'money')) and
-                    (math.ceil(slot.price * (math.random(80, 120) / 100))) or slot.price or 0,
-                metadata = slot.metadata,
-                license = slot.license,
-                currency = slot.currency,
-                grade = slot.grade
-            }
+		if Item then
+			---@type OxShopItem
+			slot = {
+				name = Item.name,
+				slot = i,
+				weight = Item.weight,
+				count = slot.count,
+				price = (server.randomprices and (not slot.currency or slot.currency == 'money')) and
+					(math.ceil(slot.price * (math.random(80, 120) / 100))) or slot.price or 0,
+				metadata = slot.metadata,
+				license = slot.license,
+				currency = slot.currency,
+				grade = slot.grade
+			}
 
-            if slot.metadata then
-                slot.weight = Inventory.SlotWeight(Item, slot, true)
-            end
+			if slot.metadata then
+				slot.weight = Inventory.SlotWeight(Item, slot, true)
+			end
 
-            shop.items[i] = slot
-        end
-    end
+			shop.items[i] = slot
+		end
+	end
 end
 
 ---@param shopType string
 ---@param properties OxShop
 local function registerShopType(shopType, properties)
-    local shopLocations = properties[locations] or properties.locations
+	local shopLocations = properties[locations] or properties.locations
 
-    if shopLocations then
-        Shops[shopType] = properties
-    else
-        Shops[shopType] = {
-            label = properties.name,
-            id = shopType,
-            groups = properties.groups or properties.jobs,
-            items = properties.inventory,
-            slots = #properties.inventory,
-            type = 'shop',
-        }
+	if shopLocations then
+		Shops[shopType] = properties
+	else
+		Shops[shopType] = {
+			label = properties.name,
+			id = shopType,
+			groups = properties.groups or properties.jobs,
+			items = properties.inventory,
+			slots = #properties.inventory,
+			type = 'shop',
+		}
 
-        setupShopItems(nil, shopType, properties.name, properties.groups or properties.jobs)
-    end
+		setupShopItems(nil, shopType, properties.name, properties.groups or properties.jobs)
+	end
 end
 
 ---@param shopType string
 ---@param id number
 local function createShop(shopType, id)
-    local shop = Shops[shopType]
+	local shop = Shops[shopType]
 
-    if not shop then return end
+	if not shop then return end
 
-    local store = (shop[locations] or shop.locations)?[id]
+	local store = (shop[locations] or shop.locations)?[id]
 
-    if not store then return end
+	if not store then return end
 
-    local groups = shop.groups or shop.jobs
-    local coords
+	local groups = shop.groups or shop.jobs
+	local coords
 
-    if shared.target then
-        if store.length then
-            local z = store.loc.z + math.abs(store.minZ - store.maxZ) / 2
-            coords = vec3(store.loc.x, store.loc.y, z)
-        else
-            coords = store.coords or store.loc
-        end
-    else
-        coords = store
-    end
+	if shared.target then
+		if store.length then
+			local z = store.loc.z + math.abs(store.minZ - store.maxZ) / 2
+			coords = vec3(store.loc.x, store.loc.y, z)
+		else
+			coords = store.coords or store.loc
+		end
+	else
+		coords = store
+	end
 
-    shop[id] = {
-        label = shop.name,
-        id = shopType .. ' ' .. id,
-        groups = groups,
-        items = table.clone(shop.inventory),
-        slots = #shop.inventory,
-        type = 'shop',
-        coords = coords,
-        distance = shared.target and shop.targets?[id]?.distance,
-    }
+	shop[id] = {
+		label = shop.name,
+		id = shopType .. ' ' .. id,
+		groups = groups,
+		items = table.clone(shop.inventory),
+		slots = #shop.inventory,
+		type = 'shop',
+		coords = coords,
+		distance = shared.target and shop.targets?[id]?.distance,
+	}
 
-    setupShopItems(id, shopType, shop.name, groups)
+	setupShopItems(id, shopType, shop.name, groups)
 
-    return shop[id]
+	return shop[id]
 end
 
 for shopType, shopDetails in pairs(lib.load('data.shops') or {}) do
-    registerShopType(shopType, shopDetails)
+	registerShopType(shopType, shopDetails)
 end
 
 ---@param shopType string
 ---@param shopDetails OxShop
 exports('RegisterShop', function(shopType, shopDetails)
-    registerShopType(shopType, shopDetails)
+	registerShopType(shopType, shopDetails)
 end)
 
 lib.callback.register('ox_inventory:openShop', function(source, data)
-    local left, shop = Inventory(source)
+	local left, shop = Inventory(source)
 
-    if not left then return end
+	if not left then return end
 
-    if data then
-        shop = Shops[data.type]
+	if data then
+		shop = Shops[data.type]
 
-        if not shop then return end
+		if not shop then return end
 
-        if not shop.items then
-            shop = (data.id and shop[data.id] or createShop(data.type, data.id))
+		if not shop.items then
+			shop = (data.id and shop[data.id] or createShop(data.type, data.id))
 
-            if not shop then return end
-        end
+			if not shop then return end
+		end
 
-        ---@cast shop OxShop
+		---@cast shop OxShop
 
-        if shop.groups then
-            local group = server.hasGroup(left, shop.groups)
-            if not group then return end
-        end
+		if shop.groups then
+			local group = server.hasGroup(left, shop.groups)
+			if not group then return end
+		end
 
-        if type(shop.coords) == 'vector3' and #(GetEntityCoords(GetPlayerPed(source)) - shop.coords) > 10 then
-            return
-        end
+		if type(shop.coords) == 'vector3' and #(GetEntityCoords(GetPlayerPed(source)) - shop.coords) > 10 then
+			return
+		end
 
-        ---@diagnostic disable-next-line: assign-type-mismatch
-        left:openInventory(left)
-        left.currentShop = shop.id
-    end
+		---@diagnostic disable-next-line: assign-type-mismatch
+		left:openInventory(left)
+		left.currentShop = shop.id
+	end
 
-    return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight },
-        shop
+	return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight },
+		shop
 end)
 
 local function canAffordItem(inv, currency, price)
-    local canAfford = price >= 0 and Inventory.GetItemCount(inv, currency) >= price
+	local canAfford = price >= 0 and Inventory.GetItemCount(inv, currency) >= price
 
-    return canAfford or {
-        type = 'error',
-        description = locale('cannot_afford',
-            ('%s%s'):format((currency == 'money' and locale('$') or math.groupdigits(price)),
-                (currency == 'money' and math.groupdigits(price) or ' ' .. Items(currency).label)))
-    }
+	return canAfford or {
+		type = 'error',
+		description = locale('cannot_afford',
+			('%s%s'):format((currency == 'money' and locale('$') or math.groupdigits(price)),
+				(currency == 'money' and math.groupdigits(price) or ' ' .. Items(currency).label)))
+	}
 end
 
 local function removeCurrency(inv, currency, price)
-    Inventory.RemoveItem(inv, currency, price)
+	Inventory.RemoveItem(inv, currency, price)
 end
 
 local TriggerEventHooks = require 'modules.hooks.server'
 
 local function isRequiredGrade(grade, rank)
-    if type(grade) == "table" then
-        for i = 1, #grade do
-            if grade[i] == rank then
-                return true
-            end
-        end
-        return false
-    else
-        return rank >= grade
-    end
+	if type(grade) == "table" then
+		for i = 1, #grade do
+			if grade[i] == rank then
+				return true
+			end
+		end
+		return false
+	else
+		return rank >= grade
+	end
 end
 
 lib.callback.register('ox_inventory:buyItem', function(source, data)
-    if data.toType ~= 'player' then return end
-    if data.count == nil then data.count = 1 end
+	if data.toType == 'player' then
+		if data.count == nil then data.count = 1 end
 
-    local playerInv = Inventory(source)
-    if not playerInv or not playerInv.currentShop then return end
+		local playerInv = Inventory(source)
 
-    local shopType, shopId = playerInv.currentShop:match('^(.-) (%d-)$')
-    if not shopType then shopType = playerInv.currentShop end
-    if shopId then shopId = tonumber(shopId) end
+		if not playerInv or not playerInv.currentShop then return end
 
-    local shop = shopId and Shops[shopType][shopId] or Shops[shopType]
-    local fromData = shop.items[data.fromSlot]
-    local toData = playerInv.items[data.toSlot]
+		local shopType, shopId = playerInv.currentShop:match('^(.-) (%d-)$')
 
-    if not fromData then return end
+		if not shopType then shopType = playerInv.currentShop end
 
-    if fromData.count then
-        if fromData.count == 0 then
-            return false, false, { type = 'error', description = locale('shop_nostock') }
-        elseif data.count > fromData.count then
-            data.count = fromData.count
-        end
-    end
+		if shopId then shopId = tonumber(shopId) end
 
-    if fromData.license and server.hasLicense and not server.hasLicense(playerInv, fromData.license) then
-        return false, false, { type = 'error', description = locale('item_unlicensed') }
-    end
+		local shop = shopId and Shops[shopType][shopId] or Shops[shopType]
+		local fromData = shop.items[data.fromSlot]
+		local toData = playerInv.items[data.toSlot]
 
-    if fromData.grade then
-        local _, rank = server.hasGroup(playerInv, shop.groups)
-        if not isRequiredGrade(fromData.grade, rank) then
-            return false, false, { type = 'error', description = locale('stash_lowgrade') }
-        end
-    end
+		if fromData then
+			if fromData.count then
+				if fromData.count == 0 then
+					return false, false, { type = 'error', description = locale('shop_nostock') }
+				elseif data.count > fromData.count then
+					data.count = fromData.count
+				end
+			end
 
-    local currency = fromData.currency or 'money'
-    local fromItem = Items(fromData.name)
-    local result = fromItem.cb and fromItem.cb('buying', fromItem, playerInv, data.fromSlot, shop)
-    if result == false then return false end
+			if fromData.license and server.hasLicense and not server.hasLicense(playerInv, fromData.license) then
+				return false, false, { type = 'error', description = locale('item_unlicensed') }
+			end
 
-    local toItem = toData and Items(toData.name)
+			if fromData.grade then
+				local _, rank = server.hasGroup(playerInv, shop.groups)
+				if not isRequiredGrade(fromData.grade, rank) then
+					return false, false, { type = 'error', description = locale('stash_lowgrade') }
+				end
+			end
 
-    local metadata, count = Items.Metadata(
-        playerInv,
-        fromItem,
-        fromData.metadata and table.clone(fromData.metadata) or {},
-        data.count
-    )
+			local currency = fromData.currency or 'money'
+			local fromItem = Items(fromData.name)
 
-    if fromItem.stack == false then
-        count = 1
-    elseif type(fromItem.stack) == "number" then
-        count = math.min(count, fromItem.stack)
-    end
+			local result = fromItem.cb and fromItem.cb('buying', fromItem, playerInv, data.fromSlot, shop)
+			if result == false then return false end
 
-    if toData and type(fromItem.stack) == "number" then
-        local maxStack = fromItem.stack
-        local spaceLeft = maxStack - toData.count
+			local toItem = toData and Items(toData.name)
 
-        if spaceLeft <= 0 then
-            return false, false, { type = 'error', description = locale('stack_full') }
-        end
+			local metadata, count = Items.Metadata(playerInv, fromItem,
+				fromData.metadata and table.clone(fromData.metadata) or {}, data.count)
+			local price = count * fromData.price
 
-        local requested = data.count
-        data.count = math.min(requested, spaceLeft)
-        count = data.count
-    end
+			if toData == nil or (fromItem.name == toItem?.name and fromItem.stack and table.matches(toData.metadata, metadata)) then
+				local newWeight = playerInv.weight + (fromItem.weight + (metadata?.weight or 0)) * count
 
-    local price = count * fromData.price
+				if newWeight > playerInv.maxWeight then
+					return false, false, { type = 'error', description = locale('cannot_carry') }
+				end
 
-    if toData == nil or (fromItem.name == toItem?.name and fromItem.stack and table.matches(toData.metadata, metadata)) then
-        local newWeight = playerInv.weight + (fromItem.weight + (metadata?.weight or 0)) * count
-        if newWeight > playerInv.maxWeight then
-            return false, false, { type = 'error', description = locale('cannot_carry') }
-        end
+				local canAfford = canAffordItem(playerInv, currency, price)
 
-        local canAfford = canAffordItem(playerInv, currency, price)
-        if canAfford ~= true then
-            return false, false, canAfford
-        end
+				if canAfford ~= true then
+					return false, false, canAfford
+				end
 
-        if not TriggerEventHooks('buyItem', {
-                source = source,
-                shopType = shopType,
-                shopId = shopId,
-                toInventory = playerInv.id,
-                toSlot = data.toSlot,
-                fromSlot = fromData,
-                itemName = fromData.name,
-                metadata = metadata,
-                count = count,
-                price = fromData.price,
-                totalPrice = price,
-                currency = currency,
-            }) then
-            return false
-        end
+				if not TriggerEventHooks('buyItem', {
+						source = source,
+						shopType = shopType,
+						shopId = shopId,
+						toInventory = playerInv.id,
+						toSlot = data.toSlot,
+						fromSlot = fromData,
+						itemName = fromData.name,
+						metadata = metadata,
+						count = count,
+						price = fromData.price,
+						totalPrice = price,
+						currency = currency,
+					}) then
+					return false
+				end
 
-        Inventory.SetSlot(playerInv, fromItem, count, metadata, data.toSlot)
-        playerInv.weight = newWeight
-        removeCurrency(playerInv, currency, price)
+				Inventory.SetSlot(playerInv, fromItem, count, metadata, data.toSlot)
+				playerInv.weight = newWeight
+				removeCurrency(playerInv, currency, price)
 
-        if fromData.count then
-            shop.items[data.fromSlot].count = fromData.count - count
-        end
+				if fromData.count then
+					shop.items[data.fromSlot].count = fromData.count - count
+				end
 
-        if server.syncInventory then server.syncInventory(playerInv) end
+				if server.syncInventory then server.syncInventory(playerInv) end
 
-        local message = locale('purchased_for', count, metadata?.label or fromItem.label,
-            (currency == 'money' and locale('$') or math.groupdigits(price)),
-            (currency == 'money' and math.groupdigits(price) or ' ' .. Items(currency).label))
+				local message = locale('purchased_for', count, metadata?.label or fromItem.label,
+					(currency == 'money' and locale('$') or math.groupdigits(price)),
+					(currency == 'money' and math.groupdigits(price) or ' ' .. Items(currency).label))
 
-        if server.loglevel > 0 then
-            if server.loglevel > 1 or fromData.price >= 500 then
-                lib.logger(playerInv.owner, 'buyItem', ('"%s" %s'):format(playerInv.label, message:lower()),
-                    ('shop:%s'):format(shop.label))
-            end
-        end
+				if server.loglevel > 0 then
+					if server.loglevel > 1 or fromData.price >= 500 then
+						lib.logger(playerInv.owner, 'buyItem', ('"%s" %s'):format(playerInv.label, message:lower()),
+							('shop:%s'):format(shop.label))
+					end
+				end
 
-        return true,
-            { data.toSlot, playerInv.items[data.toSlot], shop.items[data.fromSlot].count and shop.items[data.fromSlot],
-                playerInv.weight },
-            { type = 'success', description = message }
-    end
+				return true,
+					{ data.toSlot, playerInv.items[data.toSlot], shop.items[data.fromSlot].count and
+					shop.items[data.fromSlot], playerInv.weight }, { type = 'success', description = message }
+			end
 
-    return false, false, { type = 'error', description = locale('unable_stack_items') }
+			return false, false, { type = 'error', description = locale('unable_stack_items') }
+		end
+	end
 end)
-
 
 server.shops = Shops

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -10,308 +10,308 @@ local locations = shared.target and 'targets' or 'locations'
 ---@field weight number
 
 local function setupShopItems(id, shopType, shopName, groups)
-	local shop = id and Shops[shopType][id] or Shops[shopType] --[[@as OxShop]]
+    local shop = id and Shops[shopType][id] or Shops[shopType] --[[@as OxShop]]
 
-	for i = 1, shop.slots do
-		local slot = shop.items[i]
+    for i = 1, shop.slots do
+        local slot = shop.items[i]
 
-		if slot.grade and not groups then
-			print(('^1attempted to restrict slot %s (%s) to grade %s, but %s has no job restriction^0'):format(id,
-				slot.name, json.encode(slot.grade), shopName))
-			slot.grade = nil
-		end
+        if slot.grade and not groups then
+            print(('^1attempted to restrict slot %s (%s) to grade %s, but %s has no job restriction^0'):format(id,
+                slot.name, json.encode(slot.grade), shopName))
+            slot.grade = nil
+        end
 
-		local Item = Items(slot.name)
+        local Item = Items(slot.name)
 
-		if Item then
-			---@type OxShopItem
-			slot = {
-				name = Item.name,
-				slot = i,
-				weight = Item.weight,
-				count = slot.count,
-				price = (server.randomprices and (not slot.currency or slot.currency == 'money')) and
-				(math.ceil(slot.price * (math.random(80, 120) / 100))) or slot.price or 0,
-				metadata = slot.metadata,
-				license = slot.license,
-				currency = slot.currency,
-				grade = slot.grade
-			}
+        if Item then
+            ---@type OxShopItem
+            slot = {
+                name = Item.name,
+                slot = i,
+                weight = Item.weight,
+                count = slot.count,
+                price = (server.randomprices and (not slot.currency or slot.currency == 'money')) and
+                    (math.ceil(slot.price * (math.random(80, 120) / 100))) or slot.price or 0,
+                metadata = slot.metadata,
+                license = slot.license,
+                currency = slot.currency,
+                grade = slot.grade
+            }
 
-			if slot.metadata then
-				slot.weight = Inventory.SlotWeight(Item, slot, true)
-			end
+            if slot.metadata then
+                slot.weight = Inventory.SlotWeight(Item, slot, true)
+            end
 
-			shop.items[i] = slot
-		end
-	end
+            shop.items[i] = slot
+        end
+    end
 end
 
 ---@param shopType string
 ---@param properties OxShop
 local function registerShopType(shopType, properties)
-	local shopLocations = properties[locations] or properties.locations
+    local shopLocations = properties[locations] or properties.locations
 
-	if shopLocations then
-		Shops[shopType] = properties
-	else
-		Shops[shopType] = {
-			label = properties.name,
-			id = shopType,
-			groups = properties.groups or properties.jobs,
-			items = properties.inventory,
-			slots = #properties.inventory,
-			type = 'shop',
-		}
+    if shopLocations then
+        Shops[shopType] = properties
+    else
+        Shops[shopType] = {
+            label = properties.name,
+            id = shopType,
+            groups = properties.groups or properties.jobs,
+            items = properties.inventory,
+            slots = #properties.inventory,
+            type = 'shop',
+        }
 
-		setupShopItems(nil, shopType, properties.name, properties.groups or properties.jobs)
-	end
+        setupShopItems(nil, shopType, properties.name, properties.groups or properties.jobs)
+    end
 end
 
 ---@param shopType string
 ---@param id number
 local function createShop(shopType, id)
-	local shop = Shops[shopType]
+    local shop = Shops[shopType]
 
-	if not shop then return end
+    if not shop then return end
 
-	local store = (shop[locations] or shop.locations)?[id]
+    local store = (shop[locations] or shop.locations)?[id]
 
-	if not store then return end
+    if not store then return end
 
-	local groups = shop.groups or shop.jobs
-	local coords
+    local groups = shop.groups or shop.jobs
+    local coords
 
-	if shared.target then
-		if store.length then
-			local z = store.loc.z + math.abs(store.minZ - store.maxZ) / 2
-			coords = vec3(store.loc.x, store.loc.y, z)
-		else
-			coords = store.coords or store.loc
-		end
-	else
-		coords = store
-	end
+    if shared.target then
+        if store.length then
+            local z = store.loc.z + math.abs(store.minZ - store.maxZ) / 2
+            coords = vec3(store.loc.x, store.loc.y, z)
+        else
+            coords = store.coords or store.loc
+        end
+    else
+        coords = store
+    end
 
-	shop[id] = {
-		label = shop.name,
-		id = shopType .. ' ' .. id,
-		groups = groups,
-		items = table.clone(shop.inventory),
-		slots = #shop.inventory,
-		type = 'shop',
-		coords = coords,
-		distance = shared.target and shop.targets?[id]?.distance,
-	}
+    shop[id] = {
+        label = shop.name,
+        id = shopType .. ' ' .. id,
+        groups = groups,
+        items = table.clone(shop.inventory),
+        slots = #shop.inventory,
+        type = 'shop',
+        coords = coords,
+        distance = shared.target and shop.targets?[id]?.distance,
+    }
 
-	setupShopItems(id, shopType, shop.name, groups)
+    setupShopItems(id, shopType, shop.name, groups)
 
-	return shop[id]
+    return shop[id]
 end
 
 for shopType, shopDetails in pairs(lib.load('data.shops') or {}) do
-	registerShopType(shopType, shopDetails)
+    registerShopType(shopType, shopDetails)
 end
 
 ---@param shopType string
 ---@param shopDetails OxShop
 exports('RegisterShop', function(shopType, shopDetails)
-	registerShopType(shopType, shopDetails)
+    registerShopType(shopType, shopDetails)
 end)
 
 lib.callback.register('ox_inventory:openShop', function(source, data)
-	local left, shop = Inventory(source)
+    local left, shop = Inventory(source)
 
-	if not left then return end
+    if not left then return end
 
-	if data then
-		shop = Shops[data.type]
+    if data then
+        shop = Shops[data.type]
 
-		if not shop then return end
+        if not shop then return end
 
-		if not shop.items then
-			shop = (data.id and shop[data.id] or createShop(data.type, data.id))
+        if not shop.items then
+            shop = (data.id and shop[data.id] or createShop(data.type, data.id))
 
-			if not shop then return end
-		end
+            if not shop then return end
+        end
 
-		---@cast shop OxShop
+        ---@cast shop OxShop
 
-		if shop.groups then
-			local group = server.hasGroup(left, shop.groups)
-			if not group then return end
-		end
+        if shop.groups then
+            local group = server.hasGroup(left, shop.groups)
+            if not group then return end
+        end
 
-		if type(shop.coords) == 'vector3' and #(GetEntityCoords(GetPlayerPed(source)) - shop.coords) > 10 then
-			return
-		end
+        if type(shop.coords) == 'vector3' and #(GetEntityCoords(GetPlayerPed(source)) - shop.coords) > 10 then
+            return
+        end
 
-		---@diagnostic disable-next-line: assign-type-mismatch
-		left:openInventory(left)
-		left.currentShop = shop.id
-	end
+        ---@diagnostic disable-next-line: assign-type-mismatch
+        left:openInventory(left)
+        left.currentShop = shop.id
+    end
 
-	return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight },
-		shop
+    return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight },
+        shop
 end)
 
 local function canAffordItem(inv, currency, price)
-	local canAfford = price >= 0 and Inventory.GetItemCount(inv, currency) >= price
+    local canAfford = price >= 0 and Inventory.GetItemCount(inv, currency) >= price
 
-	return canAfford or {
-		type = 'error',
-		description = locale('cannot_afford',
-			('%s%s'):format((currency == 'money' and locale('$') or math.groupdigits(price)),
-				(currency == 'money' and math.groupdigits(price) or ' ' .. Items(currency).label)))
-	}
+    return canAfford or {
+        type = 'error',
+        description = locale('cannot_afford',
+            ('%s%s'):format((currency == 'money' and locale('$') or math.groupdigits(price)),
+                (currency == 'money' and math.groupdigits(price) or ' ' .. Items(currency).label)))
+    }
 end
 
 local function removeCurrency(inv, currency, price)
-	Inventory.RemoveItem(inv, currency, price)
+    Inventory.RemoveItem(inv, currency, price)
 end
 
 local TriggerEventHooks = require 'modules.hooks.server'
 
 local function isRequiredGrade(grade, rank)
-	if type(grade) == "table" then
-		for i = 1, #grade do
-			if grade[i] == rank then
-				return true
-			end
-		end
-		return false
-	else
-		return rank >= grade
-	end
+    if type(grade) == "table" then
+        for i = 1, #grade do
+            if grade[i] == rank then
+                return true
+            end
+        end
+        return false
+    else
+        return rank >= grade
+    end
 end
 
 lib.callback.register('ox_inventory:buyItem', function(source, data)
-	if data.toType ~= 'player' then return end
-	if data.count == nil then data.count = 1 end
+    if data.toType ~= 'player' then return end
+    if data.count == nil then data.count = 1 end
 
-	local playerInv = Inventory(source)
-	if not playerInv or not playerInv.currentShop then return end
+    local playerInv = Inventory(source)
+    if not playerInv or not playerInv.currentShop then return end
 
-	local shopType, shopId = playerInv.currentShop:match('^(.-) (%d-)$')
-	if not shopType then shopType = playerInv.currentShop end
-	if shopId then shopId = tonumber(shopId) end
+    local shopType, shopId = playerInv.currentShop:match('^(.-) (%d-)$')
+    if not shopType then shopType = playerInv.currentShop end
+    if shopId then shopId = tonumber(shopId) end
 
-	local shop = shopId and Shops[shopType][shopId] or Shops[shopType]
-	local fromData = shop.items[data.fromSlot]
-	local toData = playerInv.items[data.toSlot]
+    local shop = shopId and Shops[shopType][shopId] or Shops[shopType]
+    local fromData = shop.items[data.fromSlot]
+    local toData = playerInv.items[data.toSlot]
 
-	if not fromData then return end
+    if not fromData then return end
 
-	if fromData.count then
-		if fromData.count == 0 then
-			return false, false, { type = 'error', description = locale('shop_nostock') }
-		elseif data.count > fromData.count then
-			data.count = fromData.count
-		end
-	end
+    if fromData.count then
+        if fromData.count == 0 then
+            return false, false, { type = 'error', description = locale('shop_nostock') }
+        elseif data.count > fromData.count then
+            data.count = fromData.count
+        end
+    end
 
-	if fromData.license and server.hasLicense and not server.hasLicense(playerInv, fromData.license) then
-		return false, false, { type = 'error', description = locale('item_unlicensed') }
-	end
+    if fromData.license and server.hasLicense and not server.hasLicense(playerInv, fromData.license) then
+        return false, false, { type = 'error', description = locale('item_unlicensed') }
+    end
 
-	if fromData.grade then
-		local _, rank = server.hasGroup(playerInv, shop.groups)
-		if not isRequiredGrade(fromData.grade, rank) then
-			return false, false, { type = 'error', description = locale('stash_lowgrade') }
-		end
-	end
+    if fromData.grade then
+        local _, rank = server.hasGroup(playerInv, shop.groups)
+        if not isRequiredGrade(fromData.grade, rank) then
+            return false, false, { type = 'error', description = locale('stash_lowgrade') }
+        end
+    end
 
-	local currency = fromData.currency or 'money'
-	local fromItem = Items(fromData.name)
-	local result = fromItem.cb and fromItem.cb('buying', fromItem, playerInv, data.fromSlot, shop)
-	if result == false then return false end
+    local currency = fromData.currency or 'money'
+    local fromItem = Items(fromData.name)
+    local result = fromItem.cb and fromItem.cb('buying', fromItem, playerInv, data.fromSlot, shop)
+    if result == false then return false end
 
-	local toItem = toData and Items(toData.name)
+    local toItem = toData and Items(toData.name)
 
-	local metadata, count = Items.Metadata(
-		playerInv,
-		fromItem,
-		fromData.metadata and table.clone(fromData.metadata) or {},
-		data.count
-	)
+    local metadata, count = Items.Metadata(
+        playerInv,
+        fromItem,
+        fromData.metadata and table.clone(fromData.metadata) or {},
+        data.count
+    )
 
-	if fromItem.stack == false then
-		count = 1
-	elseif type(fromItem.stack) == "number" then
-		count = math.min(count, fromItem.stack)
-	end
+    if fromItem.stack == false then
+        count = 1
+    elseif type(fromItem.stack) == "number" then
+        count = math.min(count, fromItem.stack)
+    end
 
-	if toData and type(fromItem.stack) == "number" then
-		local maxStack = fromItem.stack
-		local spaceLeft = maxStack - toData.count
+    if toData and type(fromItem.stack) == "number" then
+        local maxStack = fromItem.stack
+        local spaceLeft = maxStack - toData.count
 
-		if spaceLeft <= 0 then
-			return false, false, { type = 'error', description = locale('stack_full') }
-		end
+        if spaceLeft <= 0 then
+            return false, false, { type = 'error', description = locale('stack_full') }
+        end
 
-		local requested = data.count
-		data.count = math.min(requested, spaceLeft)
-		count = data.count
-	end
+        local requested = data.count
+        data.count = math.min(requested, spaceLeft)
+        count = data.count
+    end
 
-	local price = count * fromData.price
+    local price = count * fromData.price
 
-	if toData == nil or (fromItem.name == toItem?.name and fromItem.stack and table.matches(toData.metadata, metadata)) then
-		local newWeight = playerInv.weight + (fromItem.weight + (metadata?.weight or 0)) * count
-		if newWeight > playerInv.maxWeight then
-			return false, false, { type = 'error', description = locale('cannot_carry') }
-		end
+    if toData == nil or (fromItem.name == toItem?.name and fromItem.stack and table.matches(toData.metadata, metadata)) then
+        local newWeight = playerInv.weight + (fromItem.weight + (metadata?.weight or 0)) * count
+        if newWeight > playerInv.maxWeight then
+            return false, false, { type = 'error', description = locale('cannot_carry') }
+        end
 
-		local canAfford = canAffordItem(playerInv, currency, price)
-		if canAfford ~= true then
-			return false, false, canAfford
-		end
+        local canAfford = canAffordItem(playerInv, currency, price)
+        if canAfford ~= true then
+            return false, false, canAfford
+        end
 
-		if not TriggerEventHooks('buyItem', {
-				source = source,
-				shopType = shopType,
-				shopId = shopId,
-				toInventory = playerInv.id,
-				toSlot = data.toSlot,
-				fromSlot = fromData,
-				itemName = fromData.name,
-				metadata = metadata,
-				count = count,
-				price = fromData.price,
-				totalPrice = price,
-				currency = currency,
-			}) then
-			return false
-		end
+        if not TriggerEventHooks('buyItem', {
+                source = source,
+                shopType = shopType,
+                shopId = shopId,
+                toInventory = playerInv.id,
+                toSlot = data.toSlot,
+                fromSlot = fromData,
+                itemName = fromData.name,
+                metadata = metadata,
+                count = count,
+                price = fromData.price,
+                totalPrice = price,
+                currency = currency,
+            }) then
+            return false
+        end
 
-		Inventory.SetSlot(playerInv, fromItem, count, metadata, data.toSlot)
-		playerInv.weight = newWeight
-		removeCurrency(playerInv, currency, price)
+        Inventory.SetSlot(playerInv, fromItem, count, metadata, data.toSlot)
+        playerInv.weight = newWeight
+        removeCurrency(playerInv, currency, price)
 
-		if fromData.count then
-			shop.items[data.fromSlot].count = fromData.count - count
-		end
+        if fromData.count then
+            shop.items[data.fromSlot].count = fromData.count - count
+        end
 
-		if server.syncInventory then server.syncInventory(playerInv) end
+        if server.syncInventory then server.syncInventory(playerInv) end
 
-		local message = locale('purchased_for', count, metadata?.label or fromItem.label,
-			(currency == 'money' and locale('$') or math.groupdigits(price)),
-			(currency == 'money' and math.groupdigits(price) or ' ' .. Items(currency).label))
+        local message = locale('purchased_for', count, metadata?.label or fromItem.label,
+            (currency == 'money' and locale('$') or math.groupdigits(price)),
+            (currency == 'money' and math.groupdigits(price) or ' ' .. Items(currency).label))
 
-		if server.loglevel > 0 then
-			if server.loglevel > 1 or fromData.price >= 500 then
-				lib.logger(playerInv.owner, 'buyItem', ('"%s" %s'):format(playerInv.label, message:lower()),
-					('shop:%s'):format(shop.label))
-			end
-		end
+        if server.loglevel > 0 then
+            if server.loglevel > 1 or fromData.price >= 500 then
+                lib.logger(playerInv.owner, 'buyItem', ('"%s" %s'):format(playerInv.label, message:lower()),
+                    ('shop:%s'):format(shop.label))
+            end
+        end
 
-		return true,
-			{ data.toSlot, playerInv.items[data.toSlot], shop.items[data.fromSlot].count and shop.items[data.fromSlot],
-				playerInv.weight },
-			{ type = 'success', description = message }
-	end
+        return true,
+            { data.toSlot, playerInv.items[data.toSlot], shop.items[data.fromSlot].count and shop.items[data.fromSlot],
+                playerInv.weight },
+            { type = 'success', description = message }
+    end
 
-	return false, false, { type = 'error', description = locale('unable_stack_items') }
+    return false, false, { type = 'error', description = locale('unable_stack_items') }
 end)
 
 

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -16,7 +16,8 @@ local function setupShopItems(id, shopType, shopName, groups)
 		local slot = shop.items[i]
 
 		if slot.grade and not groups then
-			print(('^1attempted to restrict slot %s (%s) to grade %s, but %s has no job restriction^0'):format(id, slot.name, json.encode(slot.grade), shopName))
+			print(('^1attempted to restrict slot %s (%s) to grade %s, but %s has no job restriction^0'):format(id,
+				slot.name, json.encode(slot.grade), shopName))
 			slot.grade = nil
 		end
 
@@ -29,7 +30,8 @@ local function setupShopItems(id, shopType, shopName, groups)
 				slot = i,
 				weight = Item.weight,
 				count = slot.count,
-				price = (server.randomprices and (not slot.currency or slot.currency == 'money')) and (math.ceil(slot.price * (math.random(80, 120)/100))) or slot.price or 0,
+				price = (server.randomprices and (not slot.currency or slot.currency == 'money')) and
+				(math.ceil(slot.price * (math.random(80, 120) / 100))) or slot.price or 0,
 				metadata = slot.metadata,
 				license = slot.license,
 				currency = slot.currency,
@@ -78,22 +80,22 @@ local function createShop(shopType, id)
 	if not store then return end
 
 	local groups = shop.groups or shop.jobs
-    local coords
+	local coords
 
-    if shared.target then
-        if store.length then
-            local z = store.loc.z + math.abs(store.minZ - store.maxZ) / 2
-            coords = vec3(store.loc.x, store.loc.y, z)
-        else
-            coords = store.coords or store.loc
-        end
-    else
-        coords = store
-    end
+	if shared.target then
+		if store.length then
+			local z = store.loc.z + math.abs(store.minZ - store.maxZ) / 2
+			coords = vec3(store.loc.x, store.loc.y, z)
+		else
+			coords = store.coords or store.loc
+		end
+	else
+		coords = store
+	end
 
 	shop[id] = {
 		label = shop.name,
-		id = shopType..' '..id,
+		id = shopType .. ' ' .. id,
 		groups = groups,
 		items = table.clone(shop.inventory),
 		slots = #shop.inventory,
@@ -149,7 +151,8 @@ lib.callback.register('ox_inventory:openShop', function(source, data)
 		left.currentShop = shop.id
 	end
 
-	return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight }, shop
+	return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight },
+		shop
 end)
 
 local function canAffordItem(inv, currency, price)
@@ -157,7 +160,9 @@ local function canAffordItem(inv, currency, price)
 
 	return canAfford or {
 		type = 'error',
-		description = locale('cannot_afford', ('%s%s'):format((currency == 'money' and locale('$') or math.groupdigits(price)), (currency == 'money' and math.groupdigits(price) or ' '..Items(currency).label)))
+		description = locale('cannot_afford',
+			('%s%s'):format((currency == 'money' and locale('$') or math.groupdigits(price)),
+				(currency == 'money' and math.groupdigits(price) or ' ' .. Items(currency).label)))
 	}
 end
 
@@ -169,7 +174,7 @@ local TriggerEventHooks = require 'modules.hooks.server'
 
 local function isRequiredGrade(grade, rank)
 	if type(grade) == "table" then
-		for i=1, #grade do
+		for i = 1, #grade do
 			if grade[i] == rank then
 				return true
 			end
@@ -226,7 +231,8 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 
 			local toItem = toData and Items(toData.name)
 
-			local metadata, count = Items.Metadata(playerInv, fromItem, fromData.metadata and table.clone(fromData.metadata) or {}, data.count)
+			local metadata, count = Items.Metadata(playerInv, fromItem,
+				fromData.metadata and table.clone(fromData.metadata) or {}, data.count)
 			local price = count * fromData.price
 
 			if toData == nil or (fromItem.name == toItem?.name and fromItem.stack and table.matches(toData.metadata, metadata)) then
@@ -243,19 +249,21 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 				end
 
 				if not TriggerEventHooks('buyItem', {
-					source = source,
-					shopType = shopType,
-					shopId = shopId,
-					toInventory = playerInv.id,
-					toSlot = data.toSlot,
-					fromSlot = fromData,
-					itemName = fromData.name,
-					metadata = metadata,
-					count = count,
-					price = fromData.price,
-					totalPrice = price,
-					currency = currency,
-				}) then return false end
+						source = source,
+						shopType = shopType,
+						shopId = shopId,
+						toInventory = playerInv.id,
+						toSlot = data.toSlot,
+						fromSlot = fromData,
+						itemName = fromData.name,
+						metadata = metadata,
+						count = count,
+						price = fromData.price,
+						totalPrice = price,
+						currency = currency,
+					}) then
+					return false
+				end
 
 				Inventory.SetSlot(playerInv, fromItem, count, metadata, data.toSlot)
 				playerInv.weight = newWeight
@@ -267,15 +275,20 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 
 				if server.syncInventory then server.syncInventory(playerInv) end
 
-				local message = locale('purchased_for', count, metadata?.label or fromItem.label, (currency == 'money' and locale('$') or math.groupdigits(price)), (currency == 'money' and math.groupdigits(price) or ' '..Items(currency).label))
+				local message = locale('purchased_for', count, metadata?.label or fromItem.label,
+					(currency == 'money' and locale('$') or math.groupdigits(price)),
+					(currency == 'money' and math.groupdigits(price) or ' ' .. Items(currency).label))
 
 				if server.loglevel > 0 then
 					if server.loglevel > 1 or fromData.price >= 500 then
-						lib.logger(playerInv.owner, 'buyItem', ('"%s" %s'):format(playerInv.label, message:lower()), ('shop:%s'):format(shop.label))
+						lib.logger(playerInv.owner, 'buyItem', ('"%s" %s'):format(playerInv.label, message:lower()),
+							('shop:%s'):format(shop.label))
 					end
 				end
 
-				return true, {data.toSlot, playerInv.items[data.toSlot], shop.items[data.fromSlot].count and shop.items[data.fromSlot], playerInv.weight}, { type = 'success', description = message }
+				return true,
+					{ data.toSlot, playerInv.items[data.toSlot], shop.items[data.fromSlot].count and
+					shop.items[data.fromSlot], playerInv.weight }, { type = 'success', description = message }
 			end
 
 			return false, false, { type = 'error', description = locale('unable_stack_items') }

--- a/web/src/typings/slot.ts
+++ b/web/src/typings/slot.ts
@@ -20,4 +20,5 @@ export type SlotWithItem = Slot & {
   duration?: number;
   image?: string;
   grade?: number | number[];
+  stack?: number | boolean | null;
 };


### PR DESCRIPTION
## Description  
This PR adds **native support for item stacking** across inventory and shop interactions.  
The system now respects stack limits when adding, moving, or swapping items.  

## Changes  

- **Item Adding Logic**  
  - Enforced stack limits when adding new items.  

- **Shop Interactions**  
  - Selecting a quantity higher than the stack limit will automatically clamp to the maximum allowed.  
    - Example: If *Water* has a stack limit of 5, attempting to purchase 6 will clamp to 5.  
  - Moving items respects target slot capacity.  
    - Example: If a slot has a stack limit of 5 and already contains 2 items, moving 5 items into it will only transfer 3.  
  - Attempting to move items into a fully stacked slot now results in an error.  

- **Item Swapping Logic**  
  - Swapping behaves consistently with stacking rules.  
  - If an item is moved onto another slot that has reached its max stack size, the action is prevented.  