### PR TITLE
fix(weapon/client): infinite ammo not working on petrolcan and fireextinguisher

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1509,7 +1509,7 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inven
 							currentWeapon.metadata.ammo = (weaponAmmo < currentAmmo) and 0 or currentAmmo
 
 							if currentAmmo <= 0 then
-								SetPedInfiniteAmmo(playerPed, false, currentWeapon.hash)
+								SetPedInfiniteAmmoClip(playerPed, false)
 							end
 						else
 							currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)

--- a/modules/weapon/client.lua
+++ b/modules/weapon/client.lua
@@ -82,7 +82,7 @@ function Weapon.Equip(item, data, noWeaponAnim)
 
 	if item.group == `GROUP_PETROLCAN` or item.group == `GROUP_FIREEXTINGUISHER` then
 		item.metadata.ammo = item.metadata.durability
-		SetPedInfiniteAmmo(playerPed, true, data.hash)
+		SetPedInfiniteAmmoClip(playerPed, true)
 	end
 
 	TriggerEvent('ox_inventory:currentWeapon', item)


### PR DESCRIPTION
It doesn’t work when passing the weaponHash parameter to `SetPedInfiniteAmmo`.
Leaving weaponHash empty makes the behavior identical to `SetPedInfiniteAmmoClip`.
I chose to use `SetPedInfiniteAmmoClip` instead to avoid missing parameter warnings.