### PR TITLE
Create and trigger new openShop hook on shop open

### DIFF
--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -146,12 +146,15 @@ lib.callback.register('ox_inventory:openShop', function(source, data)
 		end
 
         local hookPayload = {
-			source = source,
-			inventoryId = shop.id,
-			inventoryType = shop.type,
-		}
+            source = source,
+            shopType = shop.type,
+            shopId = shop.id,
+            label = shop.name,
+            groups = shop.groups or shop.jobs,
+            coords = shop.coords
+        }
 
-        if not TriggerEventHooks('openInventory', hookPayload) then return end
+        if not TriggerEventHooks('openShop', hookPayload) then return end
 
 		---@diagnostic disable-next-line: assign-type-mismatch
 		left:openInventory(left)

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -2,6 +2,7 @@ if not lib then return end
 
 local Items = require 'modules.items.server'
 local Inventory = require 'modules.inventory.server'
+local TriggerEventHooks = require 'modules.hooks.server'
 local Shops = {}
 local locations = shared.target and 'targets' or 'locations'
 
@@ -144,6 +145,14 @@ lib.callback.register('ox_inventory:openShop', function(source, data)
 			return
 		end
 
+        local hookPayload = {
+			source = source,
+			inventoryId = shop.id,
+			inventoryType = shop.type,
+		}
+
+        if not TriggerEventHooks('openInventory', hookPayload) then return end
+
 		---@diagnostic disable-next-line: assign-type-mismatch
 		left:openInventory(left)
 		left.currentShop = shop.id
@@ -164,8 +173,6 @@ end
 local function removeCurrency(inv, currency, price)
 	Inventory.RemoveItem(inv, currency, price)
 end
-
-local TriggerEventHooks = require 'modules.hooks.server'
 
 local function isRequiredGrade(grade, rank)
 	if type(grade) == "table" then

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -119,9 +119,9 @@ exports('RegisterShop', function(shopType, shopDetails)
 end)
 
 lib.callback.register('ox_inventory:openShop', function(source, data)
-	local left, shop = Inventory(source)
+	local playerInv, shop = Inventory(source)
 
-	if not left then return end
+	if not playerInv then return end
 
 	if data then
 		shop = Shops[data.type]
@@ -137,7 +137,7 @@ lib.callback.register('ox_inventory:openShop', function(source, data)
 		---@cast shop OxShop
 
 		if shop.groups then
-			local group = server.hasGroup(left, shop.groups)
+			local group = server.hasGroup(playerInv, shop.groups)
 			if not group then return end
 		end
 
@@ -145,9 +145,12 @@ lib.callback.register('ox_inventory:openShop', function(source, data)
 			return
 		end
 
+		local shopType, shopId = shop.id:match('^(.-) (%d-)$')
+
         local hookPayload = {
             source = source,
-            id = shop.id,
+            shopId = shopId,
+			shopType = shopType,
             label = shop.label,
             slots = shop.slots,
             items = shop.items,
@@ -159,11 +162,11 @@ lib.callback.register('ox_inventory:openShop', function(source, data)
         if not TriggerEventHooks('openShop', hookPayload) then return end
 
 		---@diagnostic disable-next-line: assign-type-mismatch
-		left:openInventory(left)
-		left.currentShop = shop.id
+		playerInv:openInventory(playerInv)
+		playerInv.currentShop = shop.id
 	end
 
-	return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight }, shop
+	return { label = playerInv.label, type = playerInv.type, slots = playerInv.slots, weight = playerInv.weight, maxWeight = playerInv.maxWeight }, shop
 end)
 
 local function canAffordItem(inv, currency, price)

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -147,11 +147,13 @@ lib.callback.register('ox_inventory:openShop', function(source, data)
 
         local hookPayload = {
             source = source,
-            shopType = shop.type,
-            shopId = shop.id,
-            label = shop.name,
-            groups = shop.groups or shop.jobs,
-            coords = shop.coords
+            id = shop.id,
+            label = shop.label,
+            slots = shop.slots,
+            items = shop.items,
+            groups = shop.groups,
+            coords = shop.coords,
+            distance = shop.distance
         }
 
         if not TriggerEventHooks('openShop', hookPayload) then return end


### PR DESCRIPTION
Trigger the `openInventory` hook when a shop is opened by the player.

Additional Notes:
- Currently, the `openedInventory` and `closedInventory` events fire when a shop is opened/closed with only data pertaining to the player who is performing the action. It may be worth modifying these events to trigger with the data of the shop instead. Please let me know if you all agree. If so, I will extend this PR to also include those changes.