### PR TITLE
Security fix: ability to open any inventory

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -231,6 +231,11 @@ local function openInventory(source, invType, data, ignoreSecurityChecks)
 
 		if not right then return end
 
+        if right.type ~= invType then
+            DropPlayer(source, 'sussy')
+            return
+         end
+
 		if not ignoreSecurityChecks and right.groups and not server.hasGroup(left, right.groups) then return end
 
 		local hookPayload = {


### PR DESCRIPTION
Current ox_inventory version (v2.44.6) has a vulnerability where users can open any inventory bypassing all security checks.
This is due to there not being any validation made on the `invType` parameter within the openInventory [function](https://github.com/CommunityOx/ox_inventory/blob/main/server.lua#L119) & [callback](https://github.com/CommunityOx/ox_inventory/blob/main/server.lua#L289).

As discussed with Linden ideal solution to allow customization with relative ease without needing to add inventory types to a separate registry, before opening another inventory check that the requested invType is equal to the inventory type. This will lead to false positives, but is only applicable to poorly created integrations where developers aren't paying attention to what they're passing as arguments.
Being that most occurrences of this would be due to people trying to exploit it, I kept the nice DropPlayer in there, can switch it to a warn log via ox_lib if judged to harsh or alter the reasons.

This can be replicated by adding the following code to demonstrate the lack of injection protection of fxserver by overriding the closeInventory function (preventing the inventory from closing due to failed security checks) and passing invalid arguments to the server to open any inventory.

```lua
RegisterCommand('injectshit', function()
    client.closeInventory = function() end

    -- 'valid_inv_id' can also be a number for targeting a player inventory
    --  'invalid_invType' can be any string excluding a used value for inventory types
    --     i.e. 'fuckwits_are_annoying', 'kek'
    --     but not 'trunk', 'player' obv...
    TriggerEvent('ox_inventory:openInventory', 'invalid_invType', 'valid_inv_id')
end)
```