### PR TITLE
Fix oversight in #53

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -231,10 +231,12 @@ local function openInventory(source, invType, data, ignoreSecurityChecks)
 
 		if not right then return end
 
-        if right.type ~= invType then
+        -- Security check to make sure the requested inventory type is the same as the found inventory
+        -- Only case where a missmatch is tolerated is for temporary stashes
+        if right.type ~= invType and not (right.type == 'temp' and invType == 'stash') then
             DropPlayer(source, 'sussy')
             return
-         end
+        end
 
 		if not ignoreSecurityChecks and right.groups and not server.hasGroup(left, right.groups) then return end
 


### PR DESCRIPTION
The security patch made in #53 made one slight oversight when patching the exploit allowing cheaters to open any inventory by simply overriding client code.
This oversight was that temporary stashes don't have their type set to `stash` but `temp`, this causes the script to treat it like a person exploiting and will drop the player.

To address this, a simple condition was added to the type check to exclude the case when the found inventory type is `temp` and the requested one is `stash`.
Another viable approach would be to alter the creation of temporary stashes to have their type be `stash` but this would require some changes to the [`Inventory.Create`](https://github.com/CommunityOx/ox_inventory/blob/7c0c32e8f1940d80bc98ad119a04d80c2a6068a7/modules/inventory/server.lua#L567) to adapt the passed variable if it's `temp` to stash. This shouldn't cause breaking changes at first glance, but it does alter a core system which I don't think is the ideal solution for this hotfix.