### PR TITLE
Fixed Hunger and Thirst Limit

### DIFF
--- a/modules/bridge/qbx/client.lua
+++ b/modules/bridge/qbx/client.lua
@@ -25,6 +25,6 @@ function client.setPlayerStatus(values)
             value = value * 0.0001
         end
 
-        playerState:set(name, playerState[name] + value, true)
+        playerState:set(name, lib.math.clamp(playerState[name] + value, 0, 100), true)
     end
 end


### PR DESCRIPTION
This fixes the problem that when someone drinks or eats something, the value of the food or drink exceeds 100 without a limit.