### PR TITLE
Add RegisterVehicleInventory server side function.

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -2767,7 +2767,8 @@ exports('InspectInventory', Inventory.InspectInventory)
 ---@param invType? 'trunk'|'glovebox' Type of vehicle inventory (default: 'trunk')
 ---@param source? number Player source for fallback vehicle class lookup
 ---@return string|nil inventoryId The created inventory ID, or nil on failure
-function Inventory.RegisterVehicleInventory(vehicleNetId, invType, source)
+function Inventory.RegisterVehicleInventory(vehicleNetId, invType)
+	local source = source
 	if not vehicleNetId then
 		return lib.print.error('RegisterVehicleInventory: vehicleNetId is required')
 	end


### PR DESCRIPTION
Introduces Inventory.RegisterVehicleInventory to allow server-side registration of vehicle trunk or glovebox. This allows servers to create vehicles inventory manually after spawning one.

Updates .gitignore to exclude web/package-lock.json.

This change follow my original modifications that allowed "trailers" to have an inventory : https://github.com/overextended/ox_inventory/pull/1282

I have developed a script based on Ox that use trailers a lot for which I need the capability to create dynamically inventories and spawn items inside them on server side.

So I propose you this merge request that can help the whole community if you enjoy it.