### PR TITLE
Fix: weapon wheel resetting

### DIFF
--- a/modules/utils/client.lua
+++ b/modules/utils/client.lua
@@ -114,11 +114,22 @@ end
 
 local rewardTypes = 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3 | 1 << 7 | 1 << 10
 
--- Enables the weapon wheel, but disables the use of inventory weapons.
--- Mostly used for weaponised vehicles, though could be called for "minigames"
-function Utils.WeaponWheel(state)
+local weaponWheelOverride = false
+
+---Enables the weapon wheel, but disables the use of inventory weapons.
+---Mostly used for weaponised vehicles, though could be called for "minigames"
+---@param state boolean
+---@param override boolean
+function Utils.WeaponWheel(state, override)
+    if not override and weaponWheelOverride and state == false then
+        return
+    end
     if client.disableweapons then state = true end
     if state == nil then state = EnableWeaponWheel end
+
+    if override then
+        weaponWheelOverride = state
+    end
 
     EnableWeaponWheel = state
     SetWeaponsNoAutoswap(not state)
@@ -130,7 +141,9 @@ function Utils.WeaponWheel(state)
     end
 end
 
-exports('weaponWheel', Utils.WeaponWheel)
+exports('weaponWheel', function (state)
+    Utils.WeaponWheel(state, true)
+end)
 
 function Utils.CreateBlip(settings, coords)
     local blip = AddBlipForCoord(coords.x, coords.y, coords.z)


### PR DESCRIPTION
This addresses and resolves the issue in #74 by adding an override variable that is only changed when the export is called.