### PR TITLE
fix (inventory/server): trunk/glovebox plate parsing offsets

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -112,12 +112,13 @@ local function loadInventoryData(data, player, ignoreSecurityChecks)
 		end
 	end
 
-	if data.type == 'trunk' or data.type == 'glovebox' then
-		local plate = data.id:sub(6)
+	local isTrunk = data.type == 'trunk'
+	if isTrunk or data.type == 'glovebox' then
+		local plate = data.id:sub(isTrunk and 6 or 9)
 
 		if server.trimplate then
 			plate = string.strtrim(plate)
-			data.id = ('%s%s'):format(data.id:sub(1, 5), plate)
+			data.id = ('%s%s'):format(data.id:sub(1, isTrunk and 5 or 8), plate)
 		end
 
 		inventory = Inventories[data.id]
@@ -168,7 +169,7 @@ local function loadInventoryData(data, player, ignoreSecurityChecks)
             if server.getOwnedVehicleId then
                 dbId = server.getOwnedVehicleId(entity)
             else
-                dbId = data.id:sub(6)
+                dbId = data.id:sub(isTrunk and 6 or 9)
             end
 
             inventory = Inventory.Create(data.id, plate, data.type, storage[1], 0, storage[2], false, nil, nil, dbId)


### PR DESCRIPTION
This PR fixes incorrect slicing for glovebox IDs by using different prefix lengths (6 vs 9 for plate extraction, and 5 vs 8 for ID reconstruction) and updates dbId extraction accordingly. The change preserves server.trimplate behavior while ensuring correct plate and inventory lookup for both types.

Before it was impossible to load inventory data for glovebox type, because all variables were made for trunk type.

// Edit:
My friend and I misunderstood the id nomenclature, this pr has no sense