### PR TITLE
feat(crafting): add zone level groups support

### DIFF
--- a/modules/crafting/client.lua
+++ b/modules/crafting/client.lua
@@ -42,14 +42,14 @@ local function createCraftingBench(id, data)
             if data.zones then
     			for i = 1, #data.zones do
     				local zone = data.zones[i]
-    				zone.name = ("craftingbench_%s:%s"):format(id, i)
+    				zone.name = ('craftingbench_%s:%s'):format(id, i)
     				zone.id = id
     				zone.index = i
     				zone.options = {
-    					{
+						{
     						label = zone.label or locale('open_crafting_bench'),
-    						canInteract = data.groups and function()
-    							return client.hasGroup(data.groups)
+    						canInteract = (zone.groups or data.groups) and function()
+    							return client.hasGroup(zone.groups or data.groups)
     						end or nil,
     						onSelect = function()
     							client.openInventory('crafting', { id = id, index = i })

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -45,6 +45,13 @@ end
 
 for id, data in pairs(lib.load('data.crafting') or {}) do createCraftingBench(data.name or id, data) end
 
+---@param bench table
+---@param index number
+---@return table?
+local function getCraftingGroups(bench, index)
+	return (shared.target and bench.zones) and bench.zones[index].groups or bench.groups
+end
+
 ---falls back to player coords if zones and points are both nil
 ---@param source number
 ---@param bench table
@@ -64,7 +71,7 @@ lib.callback.register('ox_inventory:openCraftingBench', function(source, id, ind
 	if not left then return end
 
 	if bench then
-		local groups = bench.groups
+		local groups = getCraftingGroups(bench, index)
 		local coords = getCraftingCoords(source, bench, index)
 
 		if not coords then return end
@@ -95,7 +102,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 	if not left then return end
 
 	if bench then
-		local groups = bench.groups
+		local groups = getCraftingGroups(bench, index)
 		local coords = getCraftingCoords(source, bench, index)
 
 		if groups and not server.hasGroup(left, groups) then return end


### PR DESCRIPTION
This could be used in cases where you want the same bench used by multiple groups and restrict access on zone level. Currently every defined group can open the bench at all zones.