### PR TITLE
Feat: extend image validity check to inlcude nui URIs

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -66,6 +66,12 @@ if IsDuplicityVersion() then
 				["burger", 1, 1]
 			]
 		]])),
+        validhosts = json.decode(GetConvar('inventory:validhosts', [[
+			{
+                "r2.fivemanage.com": true,
+                "i.fmfile.com": true
+            }
+		]])),
     }
 
     local accounts = json.decode(GetConvar('inventory:accounts', '["money"]'))

--- a/modules/utils/server.lua
+++ b/modules/utils/server.lua
@@ -5,10 +5,6 @@ local Utils = {}
 local webHook = GetConvar('inventory:webhook', '')
 
 if webHook ~= '' then
-	local validHosts = {
-		['i.imgur.com'] = true,
-	}
-
 	local validExtensions = {
 		['png'] = true,
 		['apng'] = true,
@@ -36,7 +32,7 @@ if webHook ~= '' then
 
             if not host or not extension then return false end
 
-            return validHosts[host] and validExtensions[extension]
+            return server.validhosts[host] and validExtensions[extension]
         end
 
         return false

--- a/modules/utils/server.lua
+++ b/modules/utils/server.lua
@@ -18,8 +18,28 @@ if webHook ~= '' then
 	local headers = { ['Content-Type'] = 'application/json' }
 
 	function Utils.IsValidImageUrl(url)
-		local host, extension = url:match('^https?://([^/]+).+%.([%l]+)')
-		return host and extension and validHosts[host] and validExtensions[extension]
+        local isUri = url:match("^nui://.+")
+        if isUri then
+            local resource, extension = url:match('^nui://([^/]+)/.-%.(%l+)$')
+
+            if not resource or not extension then return false end
+
+            local resourceState = GetResourceState(resource)
+            if resourceState ~= 'started' then return false end
+
+            return validExtensions[extension]
+        end
+
+        local isUrl = url:match("^https?://.+")
+        if isUrl then
+            local host, extension = url:match('^https?://([^/]+).+%.([%l]+)')
+
+            if not host or not extension then return false end
+
+            return validHosts[host] and validExtensions[extension]
+        end
+
+        return false
 	end
 
 	---@param title string


### PR DESCRIPTION
This pull request extends the check made by the server utility function `Utils.IsValidImageUrl` to also allow nui URI as `imageurl` in item metadata when the moderation log is enabled, it splits the check into two steps checking first if it's an nui URI then if it's a valid URL.

This PR addresses #58 issue, opens the door for easier freedom of use even if it doesn't seem like many servers use the feature.
Could be considered to have the validity check being always listed or as a separate convar to enable.

To be noted, this module requires some more attention, the valid hosts element for URL image checks still only lists 'imgur' as default valid source and needs changing being that imgur links do not function within nui.

My recommendation is to alter it to have a blacklist and a whitelist module, blacklisting by default discord and imgur urls (both do not work for fivem) and having an empty whitelist hash table. If there aren't any values for whitelisted domains

Example implementation:
```lua
local blacklistedHosts = { 'i.imgur.com', 'cdn.discordapp.com' }
local whitelistedHosts = { 'i.ibb.co' }

---@param host string
---@return boolean
local function isHostValid(host)
    -- Requires at least one whitelisted host to enforce
    if #whitelistedHosts > 0 then
        return table.contains(whitelistedHosts, host)
    else -- fallback to blacklisted domains, check that it isn't included
        return not table.contains(blacklistedHosts, host)
    end
end
```