### PR TITLE
feat: trigger `ox_inventory:usedItem` for client-side export items

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -461,7 +461,7 @@ local function useItem(data, cb, noAnim)
 end
 
 AddEventHandler('ox_inventory:usedItem', function(name, slot, metadata)
-    TriggerServerEvent('ox_inventory:usedItemInternal', slot)
+    TriggerServerEvent('ox_inventory:usedItemInternal', slot, name)
 end)
 
 AddEventHandler('ox_inventory:item', useItem)
@@ -504,9 +504,15 @@ local function useSlot(slot, noAnim)
 			if invOpen and data.close then client.closeInventory() end
 
 			if data.export then
-				return data.export(data, {name = item.name, slot = item.slot, metadata = item.metadata})
+				local result = data.export(data, {name = item.name, slot = item.slot, metadata = item.metadata})
+				if result ~= false then
+					TriggerEvent('ox_inventory:usedItem', item.name, item.slot, next(item.metadata) and item.metadata)
+				end
+				return result
 			elseif data.client.event then -- re-add it, so I don't need to deal with morons taking screenshots of errors when using trigger event
-				return TriggerEvent(data.client.event, data, {name = item.name, slot = item.slot, metadata = item.metadata})
+				TriggerEvent(data.client.event, data, {name = item.name, slot = item.slot, metadata = item.metadata})
+				TriggerEvent('ox_inventory:usedItem', item.name, item.slot, next(item.metadata) and item.metadata)
+				return
 			end
 		end
 

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -6,6 +6,7 @@ local Inventory = {}
 local Inventories = {}
 
 ---@class OxInventory
+---@field usingItem table? Set during useItem callback flow; cleared by usedItemInternal. Item data: name, label, count, slot, metadata, weight.
 local OxInventory = {}
 OxInventory.__index = OxInventory
 

--- a/server.lua
+++ b/server.lua
@@ -363,23 +363,39 @@ lib.callback.register('ox_inventory:getInventory', function(source, id)
 	}
 end)
 
-RegisterNetEvent('ox_inventory:usedItemInternal', function(slot)
+-- Supports both normal path (usingItem set by ox_inventory:useItem) and export path (slot + itemName from client).
+RegisterNetEvent('ox_inventory:usedItemInternal', function(slot, itemName)
     local inventory = Inventory(source)
 
     if not inventory then return end
 
-    local item = inventory.usingItem
+    ---@cast inventory OxInventory
+    if type(slot) ~= 'number' then return end
 
-    if not item or item.slot ~= slot then
-        ---@todo
+    local item = nil
+    local usedUsingItem = false
+
+    if inventory.usingItem and inventory.usingItem.slot == slot and (not itemName or inventory.usingItem.name == itemName) then
+        item = inventory.usingItem
+        usedUsingItem = true
+    elseif type(itemName) == 'string' and itemName ~= '' then
+        local slotItem = inventory.items[slot]
+        if slotItem and slotItem.name == itemName then
+            item = slotItem
+            if not item.slot then item.slot = slot end
+        end
+    end
+
+    if not item or not item.name or not item.slot then
         DropPlayer(inventory.id, 'sussy')
-
         return
     end
 
     TriggerEvent('ox_inventory:usedItem', inventory.id, item.name, item.slot, next(item.metadata) and item.metadata)
 
-    inventory.usingItem = nil
+    if usedUsingItem then
+        inventory.usingItem = nil
+    end
 end)
 
 ---@param source number


### PR DESCRIPTION
### Summary

This PR ensures that inventory items using **client-side exports** trigger the `ox_inventory:usedItem` event, aligning their behavior with items that use **server-side exports**.

Previously, only server-side export items reliably triggered `ox_inventory:usedItem`. Client-side export items would execute their export logic but would not fire the event on either client or server, creating an inconsistency in how item usage could be tracked.

---

### Problem

Script developers relying on the `ox_inventory:usedItem` event for:

* Logging
* Metadata processing
* Additional validation
* External integrations
* Usage-based logic

were unable to consistently integrate with items implemented using client-side exports.

This limited the extensibility and interoperability of `ox_inventory`.

---

### Solution

This PR:

* Ensures `ox_inventory:usedItem` is triggered when a client-side export item is used.
* Passes the correct:

  * Item name
  * Slot
  * Metadata (if present)
* Mirrors the behavior of server-side export items.
* Maintains backward compatibility with existing implementations.

---

### Result

Client-side and server-side export items now behave consistently with respect to the `ox_inventory:usedItem` event.

This unlocks full integration capability for script builders and standardizes item usage behavior across the framework.