### PR TITLE
Feat: setGetPlayerMethod export

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1717,10 +1717,10 @@ RegisterNUICallback('giveItem', function(data, cb)
 			local option = nearbyPlayers[i]
 
             if isGiveTargetValid(option.ped, option.coords) then
-				local playerName = GetPlayerName(option.id)
+				local playerName = Utils.getPlayerName(option.id)
 				option.id = GetPlayerServerId(option.id)
                 ---@diagnostic disable-next-line: inject-field
-				option.label = ('[%s] %s'):format(option.id, playerName)
+				option.label = playerName
 				n += 1
 				giveList[n] = option
 			end

--- a/modules/utils/client.lua
+++ b/modules/utils/client.lua
@@ -243,7 +243,6 @@ end
 ---@return string
 local function defaultGetPlayerName(serverID)
     local playerName = GetPlayerName(serverID)
-    ---@diagnostic disable-next-line: inject-field
     return ('[%d] %s'):format(serverID, playerName)
 end
 

--- a/modules/utils/client.lua
+++ b/modules/utils/client.lua
@@ -239,5 +239,26 @@ function Utils.blurOut()
     TriggerScreenblurFadeOut(250)
 end
 
+---@param serverID number
+---@return string
+local function defaultGetPlayerName(serverID)
+    local playerName = GetPlayerName(serverID)
+    ---@diagnostic disable-next-line: inject-field
+    return ('[%d] %s'):format(serverID, playerName)
+end
+
+local getPlayerName = defaultGetPlayerName
+
+exports('setGetPlayerNameMethod', function (fn)
+    if type(fn) == "function" then
+        getPlayerName = fn
+    else
+        getPlayerName = defaultGetPlayerName
+    end
+end)
+
+function Utils.getPlayerName(serverId)
+    return getPlayerName(serverId)
+end
 
 return Utils


### PR DESCRIPTION
Considering the recent support post on Discord [`Ox Inventory character name`](https://discord.com/channels/1367096780873011271/1480162460928446565).
I implemented the same system as in [ox_fuel](https://github.com/CommunityOx/ox_fuel/blob/main/server.lua#L22-L42) to allow server owners to define their own method of fetching the character name. This could also be further be directly used by supported frameworks reducing the need of editing ox_inventory code.

If changes are approved I'll open a PR to update documentation.