### PR TITLE
feat(ui): Add thousands separator formatting to item amount input

### DIFF
--- a/web/src/components/inventory/InventoryControl.tsx
+++ b/web/src/components/inventory/InventoryControl.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useDrop } from 'react-dnd';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { selectItemAmount, setItemAmount } from '../../store/inventory';
@@ -14,6 +14,9 @@ const InventoryControl: React.FC = () => {
   const dispatch = useAppDispatch();
 
   const [infoVisible, setInfoVisible] = useState(false);
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const cursorRef = useRef<{ digitsBefore: number; formattedValue: string } | null>(null);
 
   const [, use] = useDrop<DragSource, void, any>(() => ({
     accept: 'SLOT',
@@ -30,10 +33,41 @@ const InventoryControl: React.FC = () => {
   }));
 
   const inputHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-    event.target.valueAsNumber =
-      isNaN(event.target.valueAsNumber) || event.target.valueAsNumber < 0 ? 0 : Math.floor(event.target.valueAsNumber);
-    dispatch(setItemAmount(event.target.valueAsNumber));
+    const el = event.target;
+    const rawValue = el.value;
+    const selectionStart = el.selectionStart ?? 0;
+    const beforeCursor = rawValue.substring(0, selectionStart);
+    const commaCountBefore = (beforeCursor.match(/[^0-9]/g) || []).length;
+    const digits = rawValue.replace(/[^0-9]/g, "");
+    if (digits === "") {
+      setValue("");
+      dispatch(setItemAmount(0));
+      return;
+    }
+    const formatted = Number(digits).toLocaleString('en-us');
+    const digitsBeforeCursor = selectionStart - commaCountBefore;
+    setValue(formatted);
+    cursorRef.current = {
+      digitsBefore: digitsBeforeCursor,
+      formattedValue: formatted
+    };
+    const numValue = Math.floor(Math.max(0, Number(digits)));
+    dispatch(setItemAmount(isNaN(numValue) ? 0 : numValue));
   };
+  useEffect(() => {
+    if (inputRef.current && cursorRef.current !== null) {
+      const { digitsBefore, formattedValue } = cursorRef.current;
+      let newPos = 0;
+      let count = 0;
+
+      for (let i = 0; i < formattedValue.length && count < digitsBefore; i++) {
+        if (/[0-9]/.test(formattedValue[i])) count++;
+        newPos++;
+      }
+
+      inputRef.current.setSelectionRange(newPos, newPos);
+    }
+  }, [value]);
 
   return (
     <>
@@ -42,8 +76,10 @@ const InventoryControl: React.FC = () => {
         <div className="inventory-control-wrapper">
           <input
             className="inventory-control-input"
-            type="number"
+            type="text"
+            ref={inputRef}
             defaultValue={itemAmount}
+            value={value}
             onChange={inputHandler}
             min={0}
           />


### PR DESCRIPTION
## Summary

Replace the `type="number"` input with a `type="text"` input for the item
amount field in `InventoryControl`, and apply comma-separated thousands
formatting (e.g. `1,000`, `10,000`) using `toLocaleString('en-us')`.

## Changes

- Changed input type from `number` to `text`
- Format the entered value with thousands separators on each keystroke
- Preserve cursor position after formatting using `useRef` and `useEffect`
- Strip non-numeric characters before dispatching the value to the Redux store

## Motivation

The default `number` input does not display thousand separators, making it
difficult to read large quantities at a glance. This change improves
readability without affecting the underlying numeric value stored in state.

## Testing

- Type a large number (e.g. `1000000`) and verify it displays as `1,000,000`
- Verify the cursor does not jump to the end while editing mid-value
- Verify that the dispatched amount is correct (no commas included)
- Verify that empty input resets the amount to `0`

## Demo

![ox_inventory](https://github.com/user-attachments/assets/03f1a7ad-6307-42d4-9742-64dd8cd9633d)
