### PR TITLE
Tweak: include qbox r2 in valid hosts

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -69,7 +69,8 @@ if IsDuplicityVersion() then
         validhosts = json.decode(GetConvar('inventory:validhosts', [[
 			{
                 "r2.fivemanage.com": true,
-                "i.fmfile.com": true
+                "i.fmfile.com": true,
+                "r2.qbox.re": true
             }
 		]])),
     }


### PR DESCRIPTION
This PR adds r2.qbox.re as a default valid host for external image links